### PR TITLE
feat(svd): CH32V103 SVD fix and extension

### DIFF
--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -13,6 +13,8 @@ _svd: ../svd/fixed/ch32v103.svd
       - "RB_"
       - " "
 
+# TODO: unify _write_constraint rule
+
 _add:
   SYSTICK:
     description: System Tick Peripheral
@@ -763,9 +765,12 @@ EXTI:
       "IF*":
         _write_constraint: "enum"
 
-    "IF*":
+    "IF*": # FIXME: they're write-only in RM, however it seems to be readable
       _write:
         Reset: [1, "Reset interrupt flag on this line"]
+      _read:
+        NotInterrupted: [0, "This line is not interrupted"]
+        Interrupted: [1, "This line is interrupted"]
 
 PFIC:
   _delete:
@@ -1292,6 +1297,10 @@ ADC:
 
 TKEY:
   FCHARGE?:
+    _modify:
+      "TKCG*":
+        _write_constraint: "enum"
+
     "TKCG*":
       T1P5: [0, "1.5T sampling rate"]
       T7P5: [1, "7.5T sampling rate"]
@@ -1348,3 +1357,403 @@ TKEY:
       _read:
         Paused: [0, "Counting paused, TKDR availabe"]
         InProgress: [1, "Counting in progress, TKDR unavailabe"]
+
+# FIXME: some names and description seem to be inappropriate
+
+TIM1:
+  _modify:
+    "*":
+      size: 0x10
+    CHCTLR1_Input:
+      name: "CHCTLR1I"
+      displayName: "CHCTLR1I"
+    CHCTLR1_Output:
+      name: "CHCTLR1O"
+      displayName: "CHCTLR1O"
+    CHCTLR2_Input:
+      name: "CHCTLR2I"
+      displayName: "CHCTLR2I"
+    CHCTLR2_Output:
+      name: "CHCTLR2O"
+      displayName: "CHCTLR2O"
+
+  CTLR1:
+    _modify:
+      URS,DIR,CMS,CKD:
+        _write_constraint: "enum"
+
+    CEN:
+      Disabled: [0, "Counter disabled"]
+      Enabled: [1, "Counter enabled"]
+
+    UDIS:
+      Enabled: [0, "UEV enabled"]
+      Disabled: [1, "UEV disabled"]
+
+    URS:
+      Multiple: [0, "Multiple source for update event"]
+      Overflow: [1, "Only overflow can trigger update event"]
+
+    OPM:
+      Disabled: [0, "One pulse mode disabled"]
+      Enabled: [1, "One pulse mode enabled"]
+
+    DIR:
+      Decrement: [0, "Decrement counter"]
+      Increment: [1, "Increment counter"]
+
+    CMS:
+      Edge: [0, "Counter increment or dicrement according to DIR"]
+      Center1: [1, "Center alignment mode 1"]
+      Center2: [2, "Center alignment mode 2"]
+      Center3: [3, "Center alignment mode 3"]
+
+    ARPE:
+      Disabled: [0, "Auto reload preset disabled"]
+      Enabled: [1, "Auto reload preset enabled"]
+
+    CKD:
+      Tck: [0, "Tdts = Tck_int"]
+      Tck2: [1, "Tdts = Tck_int * 2"]
+      Tck4: [2, "Tdts = Tck_int * 4"]
+
+  CTLR2:
+    _modify:
+      TI1S,MMS,CCDS,CCUS,CCPC:
+        _write_constraint: "enum"
+
+    CCPC:
+      NotPreloaded: [0, "CCxE CCxNE OCxM not preloaded"]
+      Preloaded: [1, "CCxE CCxNE OCxM preloaded"]
+
+    CCUS:
+      COMOnly: [0, "Only update on COM set"]
+      Multiple: [1, "Update on COM set or TRGI rising edge"]
+
+    CCDS:
+      CHxCVR: [0, "Request DMA on CHxCVR"]
+      Update: [1, "Request DMA on update event"]
+
+    MMS:
+      Reset: [0, "TIMx_EGR register UG bit used as trigger output(TRG0)"]
+      Enable: [1, "CNT_EN bit used as trigger output(TRG0)"]
+      Update: [2, "Update event used as trigger input(TRG0)"]
+      CmpCC1IF: [3, "Trigger output(TRG0) on CC1IF set"]
+      CmpOC1REF: [4, "OC1REF signal used as trigger output(TRG0)"]
+      CmpOC2REF: [5, "OC2REF signal used as trigger output(TRG0)"]
+      CmpOC3REF: [6, "OC3REF signal used as trigger output(TRG0)"]
+      CmpOC4REF: [7, "OC4REF signal used as trigger output(TRG0)"]
+    
+    TI1S:
+      Direct: [0, "TIMx_CH1 connected directly to TI1"]
+      Xor: [1, "TIMx_CH1/2/3 connected to TI1 after xor"]
+
+  SMCFGR:
+    _modify:
+      SMS,TS,MSM,ETF,ETPS,ETP:
+        _write_constraint: "enum"
+
+    SMS:
+      Internal: [0, "Core counter driven by CK_INT"]
+      Encoder1: [1, "Core counter increment or decrement on TI1FP1 edge with respect to TI2FP2"]
+      Encoder2: [2, "Core counter increment or decrement on TI2FP2 edge with respect to TI1FP1"]
+      Encoder3: [3, "Core counter increment or decrement on TI1FP1/TI2FP2 edge with respect to another signal"]
+      Reset: [4, "Rising edge on TRGI will reset the counter"]
+      Gate: [5, "Counter clock start/stop with respect to TRGI"]
+      Trigger: [6, "Counter start on TRGI rising edge"]
+      External: [7, "Counter driven by TRGI rising edge"]
+
+    TS:
+      Internal0: [0, "ITR0 as trigger"]
+      Internal1: [1, "ITR1 as trigger"]
+      Internal2: [2, "ITR2 as trigger"]
+      Internal3: [3, "ITR3 as trigger"]
+      TI1Edge: [4, "TI1 edge dector"]
+      TI1FP1: [5, "Filtered timer input 1"]
+      TI2FP2: [6, "Filtered timer input 2"]
+      External: [7, "External trigger input"]
+
+    MSM:
+      NoEffect: [0, "No effect"]
+      TRGIDelayed: [1, "Trigger event on TRGI delayed"]
+
+    ETF:
+      NoFilter: [0, "No filter applied, sampling using Fdts"]
+      FckN2: [1, "Fsampling = Fck_int, N=2"]
+      FckN4: [2, "Fsampling = Fck_int, N=4"]
+      FckN8: [3, "Fsampling = Fck_int, N=8"]
+      Fdts2N6: [4, "Fsampling = Fdts / 2, N=6"]
+      Fdts2N8: [5, "Fsampling = Fdts / 2, N=8"]
+      Fdts4N6: [6, "Fsampling = Fdts / 4, N=6"]
+      Fdts4N8: [7, "Fsampling = Fdts / 4, N=8"]
+      Fdts8N6: [8, "Fsampling = Fdts / 8, N=6"]
+      Fdts8N8: [9, "Fsampling = Fdts / 8, N=8"]
+      Fdts16N5: [10, "Fsampling = Fdts / 16, N=5"]
+      Fdts16N6: [11, "Fsampling = Fdts / 16, N=6"]
+      Fdts16N8: [12, "Fsampling = Fdts / 16, N=8"]
+      Fdts32N5: [13, "Fsampling = Fdts / 32, N=5"]
+      Fdts32N6: [14, "Fsampling = Fdts / 32, N=6"]
+      Fdts32N8: [15, "Fsampling = Fdts / 32, N=8"]
+
+    ETPS:
+      "Off": [0, "Pre-division off"]
+      Div2: [1, "ETRP / 2"]
+      Div4: [2, "ETRP / 4"]
+      Div8: [3, "ETRP / 8"]
+
+    ECE:
+      Disabled: [0, "External Clock Mode 2 disabled"]
+      Enabled: [1, "External Clock Mode 2 enabled"]
+
+    ETP:
+      Direct: [0, "Trigger on ETR high voltage or rising edge"]
+      Inversed: [1, "Trigger on ETR low voltage or falling edge"]
+
+  DMAINTENR:
+    "*IE":
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+    "*DE":
+      Disabled: [0, "DMA disabled"]
+      Enabled: [1, "DMA enabled"]
+
+  INTFR:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
+    "*IF":
+      _write:
+        Clear: [0, "Clear interrupt flag"]
+      _read:
+        NotInterrupted: [0, "Not interrupted"]
+        Interrupted: [1, "Interrupted"]
+
+    "*OF":
+      _write:
+        Clear: [0, "Clear overcapture flag"]
+      _read:
+        NotOvercaptured: [0, "Not overcaptured"]
+        Overcaptured: [1, "Overcaptured"]
+
+  SWEVGR:
+    "*":
+      _write:
+        Generate: [1, "Generate event"]
+
+  # FIXME: CHCTLR1O/CHCTLR1I, CHCTLR2O/CHCTLR2I share the same address. Will this mess up with the ownership?
+  CHCTLR1O:
+    _modify:
+      CC?S,OC?M:
+        _write_constraint: "enum"
+
+    # FIXME: RM completely a mess here, need to verify
+    CC1S:
+      Input: [0, "CC1 configured as input"]
+      OutputTI1: [1, "CC1 configured as output. IC1 mapped to TI1"]
+      OutputTI2: [2, "CC1 configured as output. IC1 mapped to TI2"]
+      OutputTRC: [3, "CC1 configured as output. IC1 mapped to TRC"]
+
+    CC2S:
+      Input: [0, "CC2 configured as input"]
+      OutputTI2: [1, "CC2 configured as output. IC2 mapped to TI2"]
+      OutputTI1: [2, "CC2 configured as output. IC2 mapped to TI1"]
+      OutputTRC: [3, "CC2 configured as output. IC2 mapped to TRC"]
+
+    OC?FE:
+      Disabled: [0, "Fast enabling disabled"]
+      Enabled: [1, "Fast enabling enabled"] 
+
+    OC?PE:
+      Disabled: [0, "Preloading disabled"]
+      Enabled: [1, "Preloading enabled"]
+
+    OC1M:
+      Frozen: [0, "No effect on OC1REF"]
+      ForceHighCmp: [1, "OC1REF high when core counter = compare capture register"]
+      ForceLowCmp: [2, "OC1REF low when core counter = compare capture register"]
+      FlipCmp: [3, "OC1REF flipped when core counter = compare capture register"]
+      ForceLow: [4, "OC1REF set low"]
+      ForceHigh: [5, "OC1REF set high"]
+      PWM1: [6, "Before low after high"] # FIXME: PWM1/2 need better description
+      PWM2: [7, "Before high after low"]
+
+    OC2M:
+      Frozen: [0, "No effect on OC2REF"]
+      ForceHighCmp: [1, "OC2REF high when core counter = compare capture register"]
+      ForceLowCmp: [2, "OC2REF low when core counter = compare capture register"]
+      FlipCmp: [3, "OC2REF flipped when core counter = compare capture register"]
+      ForceLow: [4, "OC2REF set low"]
+      ForceHigh: [5, "OC2REF set high"]
+      PWM1: [6, "Before low after high"] # FIXME: PWM1/2 need better description
+      PWM2: [7, "Before high after low"]
+
+    OC?CE:
+      Disabled: [0, "OCxREF reset on ETRF disabled"]
+      Enabled: [1, "OCxREF reset on ETRF enabled"]
+  
+  CHCTLR1I:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
+    CC1S:
+      Output: [0, "CC1 configured as output"]
+      InputTI1: [1, "CC1 configured as input. IC1 mapped to TI1"]
+      InputTI2: [2, "CC1 configured as input. IC1 mapped to TI2"]
+      InputTRC: [3, "CC1 configured as input. IC1 mapped to TRC"]
+
+    CC2S:
+      Output: [0, "CC2 configured as output"]
+      InputTI2: [1, "CC2 configured as input. IC2 mapped to TI2"]
+      InputTI1: [2, "CC2 configured as input. IC2 mapped to TI1"]
+      InputTRC: [3, "CC2 configured as input. IC2 mapped to TRC"]
+
+    IC?PSC:
+      NoDiv: [0, "Every capture input edge will trigger a capture"]
+      Div2: [1, "Every 2 capture input edges will trigger a capture"]
+      Div4: [2, "Every 4 capture input edges will trigger a capture"]
+      Div8: [3, "Every 8 capture input edges will trigger a capture"]
+
+    IC?F:
+      NoFilter: [0, "No filter applied. Sampling using Fdts"]
+      FckN2: [1, "Fsampling = Fck_int, N=2"]
+      FckN4: [2, "Fsampling = Fck_int, N=4"]
+      FckN8: [3, "Fsampling = Fck_int, N=8"]
+      Fdts2N6: [4, "Fsampling = Fdts / 2, N=6"]
+      Fdts2N8: [5, "Fsampling = Fdts / 2, N=8"]
+      Fdts4N6: [6, "Fsampling = Fdts / 4, N=6"]
+      Fdts4N8: [7, "Fsampling = Fdts / 4, N=8"]
+      Fdts8N6: [8, "Fsampling = Fdts / 8, N=6"]
+      Fdts8N8: [9, "Fsampling = Fdts / 8, N=8"]
+      Fdts16N5: [10, "Fsampling = Fdts / 16, N=5"]
+      Fdts16N6: [11, "Fsampling = Fdts / 16, N=6"]
+      Fdts16N8: [12, "Fsampling = Fdts / 16, N=8"]
+      Fdts32N5: [13, "Fsampling = Fdts / 32, N=5"]
+      Fdts32N6: [14, "Fsampling = Fdts / 32, N=6"]
+      Fdts32N8: [15, "Fsampling = Fdts / 32, N=8"]
+
+  # FIXME: all modification applied to CHCTLR1I/O should be applied correspondingly to CHCTLR2I/O
+  CHCTLR2O:
+    _modify:
+      CC?S,OC?M:
+        _write_constraint: "enum"
+
+    CC3S:
+      Input: [0, "CC3 configured as input"]
+      OutputTI1: [1, "CC3 configured as output. IC3 mapped to TI1"]
+      OutputTI2: [2, "CC3 configured as output. IC3 mapped to TI2"]
+      OutputTRC: [3, "CC3 configured as output. IC3 mapped to TRC"]
+
+    CC4S:
+      Input: [0, "CC4 configured as input"]
+      OutputTI2: [1, "CC4 configured as output. IC4 mapped to TI2"]
+      OutputTI1: [2, "CC4 configured as output. IC4 mapped to TI1"]
+      OutputTRC: [3, "CC4 configured as output. IC4 mapped to TRC"]
+
+    OC?FE:
+      Disabled: [0, "Fast enabling disabled"]
+      Enabled: [1, "Fast enabling enabled"] 
+
+    OC?PE:
+      Disabled: [0, "Preloading disabled"]
+      Enabled: [1, "Preloading enabled"]
+
+    OC3M:
+      Frozen: [0, "No effect on OC3REF"]
+      ForceHighCmp: [1, "OC3REF high when core counter = compare capture register"]
+      ForceLowCmp: [2, "OC3REF low when core counter = compare capture register"]
+      FlipCmp: [3, "OC3REF flipped when core counter = compare capture register"]
+      ForceLow: [4, "OC3REF set low"]
+      ForceHigh: [5, "OC3REF set high"]
+      PWM1: [6, "Before low after high"] # FIXME: PWM1/2 need better description
+      PWM2: [7, "Before high after low"]
+
+    OC4M:
+      Frozen: [0, "No effect on OC4REF"]
+      ForceHighCmp: [1, "OC4REF high when core counter = compare capture register"]
+      ForceLowCmp: [2, "OC4REF low when core counter = compare capture register"]
+      FlipCmp: [3, "OC4REF flipped when core counter = compare capture register"]
+      ForceLow: [4, "OC4REF set low"]
+      ForceHigh: [5, "OC4REF set high"]
+      PWM1: [6, "Before low after high"] # FIXME: PWM1/2 need better description
+      PWM2: [7, "Before high after low"]
+
+    OC?CE:
+      Disabled: [0, "OCxREF reset on ETRF disabled"]
+      Enabled: [1, "OCxREF reset on ETRF enabled"]
+  
+  CHCTLR2I:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
+    CC3S:
+      Output: [0, "CC3 configured as output"]
+      InputTI1: [1, "CC3 configured as input. IC3 mapped to TI1"]
+      InputTI2: [2, "CC3 configured as input. IC3 mapped to TI2"]
+      InputTRC: [3, "CC3 configured as input. IC3 mapped to TRC"]
+
+    CC4S:
+      Output: [0, "CC4 configured as output"]
+      InputTI2: [1, "CC4 configured as input. IC4 mapped to TI2"]
+      InputTI1: [2, "CC4 configured as input. IC4 mapped to TI1"]
+      InputTRC: [3, "CC4 configured as input. IC4 mapped to TRC"]
+
+    IC?PSC:
+      NoDiv: [0, "Every capture input edge will trigger a capture"]
+      Div2: [1, "Every 2 capture input edges will trigger a capture"]
+      Div4: [2, "Every 4 capture input edges will trigger a capture"]
+      Div8: [3, "Every 8 capture input edges will trigger a capture"]
+
+    IC?F:
+      NoFilter: [0, "No filter applied. Sampling using Fdts"]
+      FckN2: [1, "Fsampling = Fck_int, N=2"]
+      FckN4: [2, "Fsampling = Fck_int, N=4"]
+      FckN8: [3, "Fsampling = Fck_int, N=8"]
+      Fdts2N6: [4, "Fsampling = Fdts / 2, N=6"]
+      Fdts2N8: [5, "Fsampling = Fdts / 2, N=8"]
+      Fdts4N6: [6, "Fsampling = Fdts / 4, N=6"]
+      Fdts4N8: [7, "Fsampling = Fdts / 4, N=8"]
+      Fdts8N6: [8, "Fsampling = Fdts / 8, N=6"]
+      Fdts8N8: [9, "Fsampling = Fdts / 8, N=8"]
+      Fdts16N5: [10, "Fsampling = Fdts / 16, N=5"]
+      Fdts16N6: [11, "Fsampling = Fdts / 16, N=6"]
+      Fdts16N8: [12, "Fsampling = Fdts / 16, N=8"]
+      Fdts32N5: [13, "Fsampling = Fdts / 32, N=5"]
+      Fdts32N6: [14, "Fsampling = Fdts / 32, N=6"]
+      Fdts32N8: [15, "Fsampling = Fdts / 32, N=8"]
+
+  # CCER:
+    # TODO: not documented, need discussion
+
+  BDTR:
+    _modify:
+      LOCK,OSSI,OSSR,BKP:
+        _write_constraint: "enum"
+
+    LOCK:
+      Disabled: [0, "Lock disabled"]
+      LockLevel1: [1, "DTG BKE BKP AOE OISx OISxN not writable"]
+      LockLevel2: [2, "CC polarity + OSSR OSSI + Level1"]
+      LockLevel3: [3, "CC control + Level2"]
+
+    OSSI: # FIXME: need better naming
+      NoAction: [0, "No action on idle"]
+      Output: [1, "Output idle voltage level on OC/OCN when CCxE or CCxNE=1"]
+
+    OSSR:
+      NoAction: [0, "No action on running"]
+      Output: [1, "Output low voltage level on OC/OCN when CCxE or CCxNE=1"]
+
+    BKE:
+      Disabled: [0, "Brake input disabled"]
+      Enabled: [1, "Brake input enabled"]
+    
+    BKP:
+      Low: [0, "Brake input activate on low voltage"]
+      High: [1, "Brake input activate on high voltage"]
+
+    MOE:
+      Disabled: [0, "OCx and OCxN no output or force idle"]
+      Enabled: [1, "OCx and OCxN output enabled"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -2354,3 +2354,249 @@ USART1:
     NACK:
       Disabled: [0, "NACK transmission in case of parity error is disabled"]
       Enabled: [1, "NACK transmission during parity error is enabled"]
+
+# reference: https://github.com/stm32-rs/stm32-rs/blob/master/peripherals/i2c/
+I2C1:
+  _modify:
+    "*":
+      size: 0x10
+
+  CTLR1:
+    _modify:
+      SMBUS,SMBTYPE,START,STOP,ACK,POS,ALERT,SWRST:
+        _write_constraint: "enum"
+
+    PE:
+      Disabled: [0, "I2C disabled"]
+      Enabled: [1, "I2C enabled"]
+
+    SMBUS:
+      I2C: [0, "I2C Mode"]
+      SMBus: [1, "SMBus"]
+
+    SMBTYPE:
+      Device: [0, "SMBus Device"]
+      Host: [1, "SMBus Host"]
+
+    ENARP:
+      Disabled: [0, "ARP disabled"]
+      Enabled: [1, "ARP enabled"]
+
+    ENPEC:
+      Disabled: [0, "PEC disabled"]
+      Enabled: [1, "PEC enabled"]
+
+    ENGC:
+      Disabled: [0, "General call enabled"]
+      Enabled: [1, "General call disabled"]
+
+    NOSTRETCH:
+      Enabled: [0, "Clock stretching enabled"]
+      Disabled: [1, "Clock stretching disabled"]
+
+    START:
+      NoStart: [0, "No Start generation"]
+      Start: [1, "In master mode: repeated start generation, in slave mode: start generation when bus is free"]
+
+    STOP:
+      NoStop: [0, "No Stop generation"]
+      Stop: [1, "In master mode: stop generation after current byte/start, in slave mode: release SCL and SDA after current byte"]
+
+    ACK:
+      NAK: [0, "No acknowledge returned"]
+      ACK: [1, "Acknowledge returned after a byte is received"]
+
+    POS:
+      Current: [0, "ACK bit controls the (N)ACK of the current byte being received"]
+      Next: [1, "ACK bit controls the (N)ACK of the next byte to be received"]
+
+    PEC:
+      Disabled: [0, "No PEC transfer"]
+      Enabled: [1, "PEC transfer"]
+
+    ALERT:
+      Release: [0, "SMBA pin released high"]
+      Drive: [1, "SMBA pin driven low"]
+
+    SWRST:
+      NotReset: [0, "I2C peripheral not under reset"]
+      Reset: [1, "I2C peripheral under reset"]
+
+  CTLR2:
+    _modify:
+      LAST:
+        _write_constraint: "enum"
+
+    FREQ: [2, 36]
+
+    ITERREN:
+      Disabled: [0, "Error interrupt disabled"]
+      Enabled: [1, "Error interrupt enabled"]
+
+    ITEVTEN:
+      Disabled: [0, "Event interrupt disabled"]
+      Enabled: [1, "Event interrupt enabled"]
+
+    ITBUFEN:
+      Disabled: [0, "TxE=1 or RxNE=1 does not generate any interrupt"]
+      Enabled: [1, "TxE=1 or RxNE=1 generates Event interrupt"]
+
+    DMAEN:
+      Disabled: [0, "DMA requests disabled"]
+      Enabled: [1, "DMA request enabled when TxE=1 or RxNE=1"]
+
+    LAST:
+      NotLast: [0, "Next DMA EOT is not the last transfer"]
+      Last: [1, "Next DMA EOT is the last transfer"]
+
+  OADDR1:
+    _modify:
+      ADDMODE:
+        _write_constraint: "enum"
+
+    ADDMODE:
+      ADD7: [0, "7-bit slave address"]
+      ADD10: [1, "10-bit slave address"]
+
+  OADDR2:
+    _modify:
+      ENDUAL:
+        _write_constraint: "enum"
+
+    ENDUAL:
+      Single: [0, "Single addressing mode"]
+      Dual: [1, "Dual addressing mode"]
+
+  STAR1:
+    SB:
+      _read:
+        NoStart: [0, "No Start condition"]
+        Start: [1, "Start condition generated"]
+
+    ADDR: # NOTE: RM marked this field as RW0, however it seems to be read-only
+      _read:
+        NotMatch: [0, "Adress mismatched or not received"]
+        Match: [1, "Received slave address matched with one of the enabled slave addresses"]
+
+    BTF:
+      _read:
+        NotFinished: [0, "Data byte transfer not done"]
+        Finished: [1, "Data byte transfer successful"]
+
+    ADD10:
+      _read:
+        NotSent: [0, "First address byte not sent"]
+        Sent: [1, "First address byte sent on 10-bit mode"]
+
+    STOPF:
+      _read:
+        NoStop: [0, "No Stop condition detected"]
+        Stop: [1, "Stop condition detected"]
+
+    RxNE:
+      _read:
+        Empty: [0, "Data register empty"]
+        NotEmpty: [1, "Data register not empty"]
+
+    TxE:
+      _read:
+        NotEmpty: [0, "Data register not empty"]
+        Empty: [1, "Data register empty"]
+
+    BERR:
+      _read:
+        NoError: [0, "No misplaced Start or Stop condition"]
+        Error: [1, "Misplaced Start or Stop condition"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    ARLO:
+      _read:
+        NoLost: [0, "No Arbitration Lost detected"]
+        Lost: [1, "Arbitration Lost detected"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    AF:
+      _read:
+        NoFailure: [0, "No acknowledge failure"]
+        Failure: [1, "Acknowledge failure"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    OVR:
+      _read:
+        NoOverrun: [0, "No overrun/underrun occured"]
+        Overrun: [1, "Overrun/underrun occured"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    PECERR:
+      _read:
+        NoError: [0, "no PEC error: receiver returns ACK after PEC reception (if ACK=1)"]
+        Error: [1, "PEC error: receiver returns NACK after PEC reception (whatever ACK)"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    TIMEOUT:
+      _read:
+        NoTimeout: [0, "No Timeout error"]
+        Timeout: [1, "SCL remained LOW for 25 ms"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    SMBALERT:
+      _read:
+        NoAlert: [0, "No SMBALERT occured"]
+        Alert: [1, "SMBALERT occurred"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+  STAR2:
+    MSL:
+      _read:
+        Slave: [0, "I2C working at slave mode"]
+        Master: [1, "I2C working at master mode"]
+
+    BUSY:
+      _read:
+        Idle: [0, "I2C bus is idle"]
+        Busy: [1, "I2C bus is busy"]
+
+    TRA:
+      _read:
+        Received: [0, "Data received"]
+        Transmitted: [1, "Data transmitted"]
+
+    GENCALL:
+      _read:
+        NotCalled: [0, "No general call received"]
+        Called: [1, "General call received"]
+
+    SMBDEFAULT:
+      _read:
+        NotReceived: [0, "SMBus device default address not received"]
+        Received: [1, "SMBus device default address received"]
+
+    SMBHOST:
+      _read:
+        NotReceived: [0, "SMBus host address not received"]
+        Received: [1, "SMBus host address received"]
+
+    DUALF:
+      _read:
+        OAR1: [0, "Address consistent with OAR1"]
+        OAR2: [1, "Address consistent with OAR2"]
+
+  CKCFGR:
+    _modify:
+      F_S:
+        name: FS
+
+    DUTY:
+      Duty2T1: [0, "Duty cycle t_low/t_high = 2/1"]
+      Duty16T9: [1, "Duty cycle t_low/t_high = 16/9"]
+    
+    FS:
+      Standard: [0, "Standard mode I2C"]
+      Fast: [1, "Fast mode I2C"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -2600,3 +2600,143 @@ I2C1:
     FS:
       Standard: [0, "Standard mode I2C"]
       Fast: [1, "Fast mode I2C"]
+
+# reference: https://github.com/stm32-rs/stm32-rs/blob/master/peripherals/spi/spi_common.yaml
+SPI1:
+  _modify:
+    "*":
+      size: 0x10
+
+  _delete:
+    - "I2S*"
+
+  CTLR1:
+    _modify:
+      CPHA,CPOL,MSTR,BR,LSBFIRST,SSI,RXONLY,DFF,CRCNEXT,BIDIOE,BIDIMODE:
+        _write_constraint: "enum"
+  
+    CPHA:
+      FirstEdge: [0, "The first clock transition is the first data capture edge"]
+      SecondEdge: [1, "The second clock transition is the first data capture edge"]
+
+    CPOL:
+      IdleLow: [0, "CK to 0 when idle"]
+      IdleHigh: [1, "CK to 1 when idle"]
+
+    MSTR:
+      Slave: [0, "Slave configuration"]
+      Master: [1, "Master configuration"]
+
+    BR:
+      Div2: [0, "f_PCLK / 2"]
+      Div4: [1, "f_PCLK / 4"]
+      Div8: [2, "f_PCLK / 8"]
+      Div16: [3, "f_PCLK / 16"]
+      Div32: [4, "f_PCLK / 32"]
+      Div64: [5, "f_PCLK / 64"]
+      Div128: [6, "f_PCLK / 128"]
+      Div256: [7, "f_PCLK / 256"]
+
+    SPE:
+      Disabled: [0, "Peripheral disabled"]
+      Enabled: [1, "Peripheral enabled"]
+
+    LSBFIRST:
+      MSBFirst: [0, "Data is transmitted/received with the MSB first"]
+      LSBFirst: [1, "Data is transmitted/received with the LSB first"]
+
+    SSI:
+      SlaveSelected: [0, "0 is forced onto the NSS pin and the I/O value of the NSS pin is ignored"]
+      SlaveNotSelected: [1, "1 is forced onto the NSS pin and the I/O value of the NSS pin is ignored"]
+
+    SSM:
+      Disabled: [0, "Software slave management disabled"]
+      Enabled: [1, "Software slave management enabled"]
+
+    RXONLY:
+      FullDuplex: [0, "Full duplex (Transmit and receive)"]
+      OutputDisabled: [1, "Output disabled (Receive-only mode)"]
+
+    DFF:
+      D8: [0, "Data length 8 bits"]
+      D16: [1, "Data length 16 bits"]
+
+    CRCNEXT:
+      TxBuffer: [0, "Next transmit value is from Tx buffer"]
+      CRC: [1, "Next transmit value is from Tx CRC register"]
+
+    CRCEN:
+      Disabled: [0, "CRC calculation disabled"]
+      Enabled: [1, "CRC calculation enabled"]
+
+    BIDIOE:
+      OutputDisabled: [0, "Output disabled (receive-only mode)"]
+      OutputEnabled: [1, "Output enabled (transmit-only mode)"]
+
+    BIDIMODE:
+      Unidirectional: [0, "2-line unidirectional data mode selected"]
+      Bidirectional: [1, "1-line bidirectional data mode selected"]
+
+  CTLR2:
+    RXDMAEN:
+      Disabled: [0, "Rx buffer DMA disabled"]
+      Enabled: [1, "Rx buffer DMA enabled"]
+
+    TXDMAEN:
+      Disabled: [0, "Tx buffer DMA disabled"]
+      Enabled: [1, "Tx buffer DMA enabled"]
+
+    SSOE:
+      Disabled: [0, "SS output is disabled in master mode"]
+      Enabled: [1, "SS output is enabled in master mode"]
+
+    "*IE":
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+
+  STATR:
+    _modify:
+      CRCERR,MODF,OVR:
+        _write_constraint: "enum"
+      
+      # NOTE: RM states they're reset by software
+      MODF:
+        access: read-write
+      
+      OVR:
+        access: read-write
+
+    RXNE:
+      _read:
+        Empty: [0, "Rx buffer empty"]
+        NotEmpty: [1, "Rx buffer not empty"]
+
+    TXE:
+      NotEmpty: [0, "Tx buffer not empty"]
+      Empty: [1, "Tx buffer empty"]
+
+    CRCERR:
+      _read:
+        Match: [0, "CRC value received matches the SPIx_RXCRCR value"]
+        NoMatch: [1, "CRC value received does not match the SPIx_RXCRCR value"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    MODF:
+      _read:
+        NoFault: [0, "No mode fault occurred"]
+        Fault: [1, "Mode fault occurred"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    OVR:
+      _read:
+        NoOverrun: [0, "No overrun occurred"]
+        Overrun: [1, "Overrun occurred"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    BSY:
+      _read:
+        NotBusy: [0, "SPI not busy"]
+        Busy: [1, "SPI busy"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -17,6 +17,7 @@ _svd: ../svd/fixed/ch32v103.svd
 
 _include:
   - "../peripherals/usbd.yaml"
+  - "../peripherals/flash.yaml"
 
 _modify:
   TIM2:

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -13,6 +13,257 @@ _svd: ../svd/fixed/ch32v103.svd
       - "RB_"
       - " "
 
+_add:
+  SYSTICK:
+    description: System Tick Peripheral
+    groupName: SYSTICK
+    baseAddress: 0xE000F000
+    addressBlock:
+      offset: 0x0
+      size: 0x14 # FIXME: need to verify
+      usage: "registers"
+    registers:
+      CTLR:
+        description: SysTick Control register
+        addressOffset: 0x0
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          STE:
+            description: SysTick enable state
+            bitOffset: 0
+            bitWidth: 1
+      CNTL:
+        description: SysTick counter low bits
+        addressOffset: 0x4
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          CNTL:
+            description: SysTick counter low bits
+            bitOffset: 0
+            bitWidth: 32
+      CNTH:
+        description: SysTick counter high bits
+        addressOffset: 0x8
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          CNTL:
+            description: SysTick counter high bits
+            bitOffset: 0
+            bitWidth: 32
+      CMPLR:
+        description: SysTick compare low bits
+        addressOffset: 0xC
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          CNTL:
+            description: SysTick compare low bits
+            bitOffset: 0
+            bitWidth: 32
+      CMPHR:
+        description: SysTick compare high bits
+        addressOffset: 0x10
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          CNTL:
+            description: SysTick compare high bits
+            bitOffset: 0
+            bitWidth: 32
+
+  TKEY: # TODO: check compatibility with ADC
+    description: Touch Key Peripheral
+    groupName: ADC
+    baseAddress: 0x40012400
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    registers:
+      FCHARGE1:
+        description: TKEY_F charge control register
+        addressOffset: 0xC
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          TKCG10:
+            description: Touch key configuration channel 10
+            bitOffset: 0
+            bitWidth: 3
+          TKCG11:
+            description: Touch key configuration channel 11
+            bitOffset: 3
+            bitWidth: 3
+          TKCG12:
+            description: Touch key configuration channel 12
+            bitOffset: 6
+            bitWidth: 3
+          TKCG13:
+            description: Touch key configuration channel 13
+            bitOffset: 9
+            bitWidth: 3
+          TKCG14:
+            description: Touch key configuration channel 14
+            bitOffset: 12
+            bitWidth: 3
+          TKCG15:
+            description: Touch key configuration channel 15
+            bitOffset: 15
+            bitWidth: 3
+          TKCG16:
+            description: Touch key configuration channel 16
+            bitOffset: 18
+            bitWidth: 3
+          TKCG17:
+            description: Touch key configuration channel 17
+            bitOffset: 21
+            bitWidth: 3
+
+      FCHARGE2:
+        description: TKEY_F charge control register
+        addressOffset: 0x10
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          TKCG0:
+            description: Touch key configuration channel 0
+            bitOffset: 0
+            bitWidth: 3
+
+          TKCG1:
+            description: Touch key configuration channel 1
+            bitOffset: 3
+            bitWidth: 3
+
+          TKCG2:
+            description: Touch key configuration channel 2
+            bitOffset: 6
+            bitWidth: 3
+
+          TKCG3:
+            description: Touch key configuration channel 3
+            bitOffset: 9
+            bitWidth: 3
+
+          TKCG4:
+            description: Touch key configuration channel 4
+            bitOffset: 12
+            bitWidth: 3
+
+          TKCG5:
+            description: Touch key configuration channel 5
+            bitOffset: 15
+            bitWidth: 3
+
+          TKCG6:
+            description: Touch key configuration channel 6
+            bitOffset: 18
+            bitWidth: 3
+
+          TKCG7:
+            description: Touch key configuration channel 7
+            bitOffset: 21
+            bitWidth: 3
+
+          TKCG8:
+            description: Touch key configuration channel 8
+            bitOffset: 24
+            bitWidth: 3
+
+          TKCG9:
+            description: Touch key configuration channel 9
+            bitOffset: 27
+            bitWidth: 3
+
+      FDISCHARGE:
+        description: TKEY_F charge control register
+        addressOffset: 0x3C
+        access: write-only
+        resetValue: 0x00000000
+        fields:
+          TKDCRGT:
+            description: TKEY_F discharge time
+            bitOffset: 0
+            bitWidth: 8
+
+      FACT:
+        description: TKEY_F act register
+        addressOffset: 0x4C
+        access: write-only
+        resetValue: 0x00000000
+        fields:
+          TKACT:
+            description: TKEY_F action
+            bitOffset: 0
+            bitWidth: 8
+
+      FDR:
+        description: TKEY_F data register
+        addressOffset: 0x4C
+        access: read-only
+        resetValue: 0x00000000
+        fields:
+          DATA:
+            description: Converted data
+            bitOffset: 0
+            bitWidth: 8
+
+      VCTLR:
+        description: TKEY_V control register
+        addressOffset: 0x4
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          TKENABLE:
+            description: TKEY module enable state
+            bitOffset: 24
+            bitWidth: 1
+          TKIEN:
+            description: TKEY counting complete interrupt enable state
+            bitOffset: 25
+            bitWidth: 1
+          TKCPS:
+            description: TKEY counting period selection
+            bitOffset: 26
+            bitWidth: 1
+          TKIF:
+            description: TKEY counting complete flag
+            bitOffset: 27
+            bitWidth: 1
+          CCSEL:
+            description: TKEY_V counting period base frequency
+            bitOffset: 28
+            bitWidth: 3
+      
+      VCHANNEL:
+        description: TKEY_V channel register
+        addressOffset: 0x34
+        access: read-write # read-only on RM, but writing operation is legal
+        resetValue: 0x00000000
+        fields:
+          CHSEL:
+            description: TKEY_V channel selection
+            bitOffset: 0
+            bitWidth: 5
+
+      VSDR:
+        description: TKEY_V state data register
+        addressOffset: 0x4C
+        access: read-only
+        resetValue: 0x00008000
+        fields:
+          TKDR:
+            description: TKEY_V counting conversion value
+            bitOffset: 0
+            bitWidth: 14
+          TKSTA:
+            description: TKEY_V operation state
+            bitOffset: 15
+            bitWidth: 1
+
 PWR:
   CTLR:
     _modify:
@@ -589,67 +840,6 @@ PFIC:
       _write:
         Set: [1, "Set WFE event"]
 
-_add:
-  SYSTICK:
-    description: System Tick Peripheral
-    groupName: SYSTICK
-    baseAddress: 0xE000F000
-    addressBlock:
-      offset: 0x0
-      size: 0x14 # FIXME: need to verify
-      usage: "registers"
-    registers:
-      CTLR:
-        description: SysTick Control register
-        addressOffset: 0x0
-        access: read-write
-        resetValue: 0x00000000
-        fields:
-          STE:
-            description: SysTick enable state
-            bitOffset: 0
-            bitWidth: 1
-      CNTL:
-        description: SysTick counter low bits
-        addressOffset: 0x4
-        access: read-write
-        resetValue: 0x00000000
-        fields:
-          CNTL:
-            description: SysTick counter low bits
-            bitOffset: 0
-            bitWidth: 32
-      CNTH:
-        description: SysTick counter high bits
-        addressOffset: 0x8
-        access: read-write
-        resetValue: 0x00000000
-        fields:
-          CNTL:
-            description: SysTick counter high bits
-            bitOffset: 0
-            bitWidth: 32
-      CMPLR:
-        description: SysTick compare low bits
-        addressOffset: 0xC
-        access: read-write
-        resetValue: 0x00000000
-        fields:
-          CNTL:
-            description: SysTick compare low bits
-            bitOffset: 0
-            bitWidth: 32
-      CMPHR:
-        description: SysTick compare high bits
-        addressOffset: 0x10
-        access: read-write
-        resetValue: 0x00000000
-        fields:
-          CNTL:
-            description: SysTick compare high bits
-            bitOffset: 0
-            bitWidth: 32
-
 SYSTICK:
   CTLR:
     STE:
@@ -1074,3 +1264,87 @@ ADC:
       T55P5: [5, "55.5T sampling rate"]
       T71P5: [6, "71.5T sampling rate"]
       T239P5: [7, "239.5T sampling rate"]
+
+  IOFR?:
+    _modify:
+      JOFFSET?:
+        name: "IOFFSET"
+
+  ISQR:
+    _modify:
+      JSQ1:
+        name: "ISQ1"
+      JSQ2:
+        name: "ISQ2"
+      JSQ3:
+        name: "ISQ3"
+      JSQ4:
+        name: "ISQ4"
+      JL:
+        name: "ILEN"
+
+  IDATAR?:
+    _modify:
+      JDATA:
+        name: "IDATA"
+  
+  # TODO: modify SQy in RSQRx to RSQy
+
+TKEY:
+  FCHARGE?:
+    "TKCG*":
+      T1P5: [0, "1.5T sampling rate"]
+      T7P5: [1, "7.5T sampling rate"]
+      T13P5: [2, "13.5T sampling rate"]
+      T28P5: [3, "28.5T sampling rate"]
+      T41P5: [4, "41.5T sampling rate"]
+      T55P5: [5, "55.5T sampling rate"]
+      T71P5: [6, "71.5T sampling rate"]
+      T239P5: [7, "239.5T sampling rate"]
+
+  FACT:
+    _modify:
+      TKACT:
+        _write_constraint: "enum"
+
+    TKACT:
+      _write:
+        Launch: [0x00, "Start TKEY_F channel detection"]
+
+  VCTLR:
+    _modify:
+      TKIF,CCSEL:
+        _write_constraint: "enum"
+
+    TKENABLE:
+      Disabled: [0, "TKEY module disabled"]
+      Enabled: [1, "TKEY module enabled"]
+
+    TKIEN:
+      Disabled: [0, "TKEY_V interrupt disabled"]
+      Enabled: [1, "TKEY_V interrupt enabled"]
+
+    TKCPS:
+      T500US: [0, "Counting conversion period 500us"]
+      T1MS: [1, "Counting conversion period 1ms"]
+
+    TKIF:
+      _write:
+        Clear: [1, "Clear this flag"]
+      _read:
+        InProgress: [0, "TKEY_V counting in progress"]
+        Done: [1, "TKEY_V counting done"]
+
+    CCSEL:
+      T8MHz: [0, "TKEY_V counting period base frequency 8MHz"]
+      T12MHz: [1, "TKEY_V counting period base frequency 12MHz"]
+      T24MHz: [2, "TKEY_V counting period base frequency 24MHz"]
+      T36MHz: [3, "TKEY_V counting period base frequency 36MHz"]
+      T48MHz: [4, "TKEY_V counting period base frequency 48MHz"]
+      T56MHz: [5, "TKEY_V counting period base frequency 56MHz"]
+
+  VSDR:
+    TKSTA:
+      _read:
+        Paused: [0, "Counting paused, TKDR availabe"]
+        InProgress: [1, "Counting in progress, TKDR unavailabe"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -2181,3 +2181,176 @@ DAC1:
     DMAEN?:
       Disabled: [0, "DAC channel DMA disabled"]
       Enabled: [1, "DAC channel DMA enabled"]
+
+USART1:
+  STATR:
+    _modify:
+      RXNE,TC,LBD,CTS:
+        _write_constraint: "enum"
+
+    PE,FE,NE,ORE:
+      _read:
+        NoError: [0, "No error occurred"]
+        HasError: [1, "Error occurred"]
+
+    IDLE:
+      _read:
+        Busy: [0, "Line busy"]
+        Idle: [1, "Line idle"]
+
+    RXNE:
+      _read:
+        Waiting: [0, "Waiting for data"]
+        Readable: [1, "Data received, register readable"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    TC:
+      _read:
+        InProgress: [0, "Transmission in progress"]
+        Completed: [1, "Transmission completed"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    TXE:
+      _read:
+        InProgress: [0, "Data transfer in progress"]
+        Transferred: [1, "Data transfer completed"]
+
+    LBD:
+      _read:
+        Connected: [0, "LIN disconnection not detected"]
+        Disconnected: [1, "LIN disconnection detected"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    CTS:
+      _read:
+        NoChange: [0, "No change detected on nCTS"]
+        Changed: [1, "Change detected on nCTS"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+  CTLR1:
+    _modify:
+      SBK,RWU,PS,WAKE,M:
+        _write_constraint: "enum"
+
+    SBK:
+      NoBreak: [0, "No break character is transmitted"]
+      Break: [1, "Break character transmitted"]
+
+    RWU:
+      Active: [0, "Receiver in active mode"]
+      Muted: [1, "Receiver in mute mode"]
+      
+    RE,TE:
+      Disabled: [0, "Module disabled"]
+      Enabled: [1, "Module enabled"]
+
+    "*IE":
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+
+    PS:
+      Even: [0, "Even parity check"]
+      Odd: [1, "Odd parity check"]
+
+    WAKE:
+      IdleLine: [0, "USART wake up on idle line"]
+      AddressMark: [1, "USART wake up on address mark"]
+
+    M:
+      L8: [0, "Word length 8 data bits"]
+      L9: [1, "Word length 9 data bits"]
+
+    UE: # TODO: check if the RM is wrong. It is different from STM32?
+      Enabled: [0, "USART enabled"]
+      Disabled: [1, "USART disabled"]
+
+  CTLR2:
+    _modify:
+      LBDL,CPHA,CPOL,STOP:
+        _write_constraint: "enum"
+
+    LBDL:
+      LBDL10: [0, "10-bit break detection"]
+      LBDL11: [1, "11-bit break detection"]
+
+    LBDIE:
+      Disabled: [0, "LIN break detection disabled"]
+      Enabled: [1, "LIN break detection enabled"]
+
+    LBCL: # FIXME: document wrong here
+
+    # reference: https://github.com/stm32-rs/stm32-rs/blob/master/peripherals/usart/
+    CPHA:
+      First: [0, "The first clock transition is the first data capture edge"]
+      Second: [1, "The second clock transition is the first data capture edge"]  
+    
+    CPOL:
+      Low: [0, "Steady low value on CK pin outside transmission window"]
+      High: [1, "Steady high value on CK pin outside transmission window"]
+    
+    CLKEN:
+      Disabled: [0, "CK pin disabled"]
+      Enabled: [1, "CK pin enabled"]
+    
+    STOP:
+      Stop1: [0, "1 stop bit"]
+      Stop0p5: [1, "0.5 stop bits"]
+      Stop2: [2, "2 stop bits"]
+      Stop1p5: [3, "1.5 stop bits"]
+
+    LINEN:
+      Disabled: [0, "LIN mode disabled"]
+      Enabled: [1, "LIN mode enabled"]
+    
+  CTLR3:
+    _modify:
+      HDSEL,IRLP:
+        _write_constraint: "enum"
+
+    DMAT:
+      Disabled: [0, "DMA mode is disabled for transmission"]
+      Enabled: [1, "DMA mode is enabled for transmission"]
+
+    DMAR:
+      Disabled: [0, "DMA mode is disabled for reception"]
+      Enabled: [1, "DMA mode is enabled for reception"]
+
+    HDSEL:
+      FullDuplex: [0, "Half duplex mode is not selected"]
+      HalfDuplex: [1, "Half duplex mode is selected"]
+
+    IRLP:
+      Normal: [0, "Normal mode"]
+      LowPower: [1, "Low-power mode"]
+
+    IREN:
+      Disabled: [0, "IrDA disabled"]
+      Enabled: [1, "IrDA enabled"]
+
+    EIE:
+      Disabled: [0, "Error interrupt disabled"]
+      Enabled: [1, "Error interrupt enabled"]
+
+    CTSIE:
+      Disabled: [0, "CTS interrupt disabled"]
+      Enabled: [1, "CTS interrupt enabled"]
+
+    CTSE:
+      Disabled: [0, "CTS hardware flow control disabled"]
+      Enabled: [1, "CTS hardware flow control enabled"]
+
+    RTSE:
+      Disabled: [0, "RTS hardware flow control disabled"]
+      Enabled: [1, "RTS hardware flow control enabled"]
+
+    SCEN:
+      Disabled: [0, "Smartcard mode disabled"]
+      Enabled: [1, "Smartcard mode enabled"]
+
+    NACK:
+      Disabled: [0, "NACK transmission in case of parity error is disabled"]
+      Enabled: [1, "NACK transmission during parity error is enabled"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -15,6 +15,9 @@ _svd: ../svd/fixed/ch32v103.svd
 
 # TODO: unify _write_constraint rule
 
+_include:
+  - "../peripherals/usbd.yaml"
+
 _modify:
   TIM2:
     description: General timer
@@ -285,11 +288,11 @@ PWR:
       StandBy: [1, "Turn into stand-by mode on deepsleep"]
 
     CWUF:
-      _write:
+      _W1C:
         Clear: [1, "Clear Wake-Up Flag"]
 
     CSBF:
-      _write:
+      _W1C:
         Clear: [1, "Clear Stand-By Flag"]
 
     PLS:
@@ -417,7 +420,7 @@ RCC:
 
     
     "*C":
-      _write:
+      _W1C:
         Clear: [1, "Clear interrupt flag"]
 
   APB?PRSTR,AHBRSTR:
@@ -477,7 +480,7 @@ RCC:
         HasReset: [1, "Reset occurred"]
 
     RMVF:
-      _write:
+      _W1C:
         Clear: [1, "Remove reset flags"]
 
     LSIRDY:
@@ -523,7 +526,7 @@ EXTEND:
       _read:
         Normal: [0, "No lock-up reset occurred"]
         Reset: [1, "Lock-up reset occurred"]
-      _write:
+      _W1C:
         Clear: [1, "Clear reset flag"]
 
     LDOTRIM:
@@ -571,11 +574,11 @@ BKP:
         _write_constraint: "enum"
 
     CTE:
-      _write:
+      _W1C:
         Clear: [1, "Clear tamper event flag"]
 
     CTI:
-      _write:
+      _W1C:
         Clear: [1, "Clear tamper interrupt flag"]
 
     TPIE:
@@ -624,14 +627,14 @@ RTC:
       _read:
         NoEvent: [0, "No event occurred"]
         HasEvent: [1, "Event occurred"]
-      _write:
+      _W0C:
         Clear: [0, "Clear event flag"]
 
     RSF:
       _read:
         NotSynchronized: [0, "Registers not synchronized"]
         Synchronized: [1, "Registers synchronized"]
-      _write:
+      _W0C:
         Reset: [0, "Reset synchronization state"]
 
     CNF:
@@ -723,7 +726,7 @@ WWDG:
       _read:
         Normal: [0, "No early wake up"]
         WakenUp: [1, "Early wake up occurred"]
-      _write:
+      _W0C:
         Reset: [0, "Reset early wake up flag"]
 
 EXTI:
@@ -770,7 +773,7 @@ EXTI:
         _write_constraint: "enum"
 
     "IF*": # FIXME: they're write-only in RM, however it seems to be readable
-      _write:
+      _W1C:
         Reset: [1, "Reset interrupt flag on this line"]
       _read:
         NotInterrupted: [0, "This line is not interrupted"]
@@ -1054,7 +1057,8 @@ DMA:
         _write_constraint: "enum"
 
     "*":
-      Clear: [1, "Clear the flag"]
+      _W1C:
+        Clear: [1, "Clear the flag"]
 
   CFGR?:
     _modify:
@@ -1121,21 +1125,21 @@ ADC:
       _read:
         NoEvent: [0, "No analog watch dog event occurred"]
         HasEvent: [1, "Analog watch dog event occurred"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     EOC,IEOC:
       _read:
         InProgress: [0, "Conversion in progress"]
         Completed: [1, "Conversion completed"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     ISTRT,RSTRT:
       _read:
         Idle: [0, "Conversion not started"]
         Started: [1, "Conversion started"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
   CTLR1:
@@ -1213,7 +1217,7 @@ ADC:
         Calibrating: [1, "Calibration in progress"]
 
     RSTCAL:
-      _write:
+      _W1C:
         Reset: [1, "Reset calibration"]
       _read:
         Done: [0, "Reset done"]
@@ -1342,7 +1346,7 @@ TKEY:
       T1MS: [1, "Counting conversion period 1ms"]
 
     TKIF:
-      _write:
+      _W1C:
         Clear: [1, "Clear this flag"]
       _read:
         InProgress: [0, "TKEY_V counting in progress"]
@@ -1527,14 +1531,14 @@ TIM1:
         _write_constraint: "enum"
 
     "*IF":
-      _write:
+      _W0C:
         Clear: [0, "Clear interrupt flag"]
       _read:
         NotInterrupted: [0, "Not interrupted"]
         Interrupted: [1, "Interrupted"]
 
     "*OF":
-      _write:
+      _W0C:
         Clear: [0, "Clear overcapture flag"]
       _read:
         NotOvercaptured: [0, "Not overcaptured"]
@@ -1929,14 +1933,14 @@ TIM2:
         _write_constraint: "enum"
 
     "*IF":
-      _write:
+      _W0C:
         Clear: [0, "Clear interrupt flag"]
       _read:
         NotInterrupted: [0, "Not interrupted"]
         Interrupted: [1, "Interrupted"]
 
     "*OF":
-      _write:
+      _W0C:
         Clear: [0, "Clear overcapture flag"]
       _read:
         NotOvercaptured: [0, "Not overcaptured"]
@@ -2202,14 +2206,14 @@ USART1:
       _read:
         Waiting: [0, "Waiting for data"]
         Readable: [1, "Data received, register readable"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     TC:
       _read:
         InProgress: [0, "Transmission in progress"]
         Completed: [1, "Transmission completed"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     TXE:
@@ -2221,14 +2225,14 @@ USART1:
       _read:
         Connected: [0, "LIN disconnection not detected"]
         Disconnected: [1, "LIN disconnection detected"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     CTS:
       _read:
         NoChange: [0, "No change detected on nCTS"]
         Changed: [1, "Change detected on nCTS"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
   CTLR1:
@@ -2507,49 +2511,49 @@ I2C1:
       _read:
         NoError: [0, "No misplaced Start or Stop condition"]
         Error: [1, "Misplaced Start or Stop condition"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     ARLO:
       _read:
         NoLost: [0, "No Arbitration Lost detected"]
         Lost: [1, "Arbitration Lost detected"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     AF:
       _read:
         NoFailure: [0, "No acknowledge failure"]
         Failure: [1, "Acknowledge failure"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     OVR:
       _read:
         NoOverrun: [0, "No overrun/underrun occured"]
         Overrun: [1, "Overrun/underrun occured"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     PECERR:
       _read:
         NoError: [0, "no PEC error: receiver returns ACK after PEC reception (if ACK=1)"]
         Error: [1, "PEC error: receiver returns NACK after PEC reception (whatever ACK)"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     TIMEOUT:
       _read:
         NoTimeout: [0, "No Timeout error"]
         Timeout: [1, "SCL remained LOW for 25 ms"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     SMBALERT:
       _read:
         NoAlert: [0, "No SMBALERT occured"]
         Alert: [1, "SMBALERT occurred"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
   STAR2:
@@ -2589,15 +2593,11 @@ I2C1:
         OAR2: [1, "Address consistent with OAR2"]
 
   CKCFGR:
-    _modify:
-      F_S:
-        name: FS
-
     DUTY:
       Duty2T1: [0, "Duty cycle t_low/t_high = 2/1"]
       Duty16T9: [1, "Duty cycle t_low/t_high = 16/9"]
     
-    FS:
+    F_S:
       Standard: [0, "Standard mode I2C"]
       Fast: [1, "Fast mode I2C"]
 
@@ -2719,21 +2719,21 @@ SPI1:
       _read:
         Match: [0, "CRC value received matches the SPIx_RXCRCR value"]
         NoMatch: [1, "CRC value received does not match the SPIx_RXCRCR value"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     MODF:
       _read:
         NoFault: [0, "No mode fault occurred"]
         Fault: [1, "Mode fault occurred"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     OVR:
       _read:
         NoOverrun: [0, "No overrun occurred"]
         Overrun: [1, "Overrun occurred"]
-      _write:
+      _W0C:
         Clear: [0, "Clear this flag"]
 
     BSY:

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -15,6 +15,10 @@ _svd: ../svd/fixed/ch32v103.svd
 
 # TODO: unify _write_constraint rule
 
+_modify:
+  TIM2:
+    description: General timer
+
 _add:
   SYSTICK:
     description: System Tick Peripheral
@@ -1757,3 +1761,374 @@ TIM1:
     MOE:
       Disabled: [0, "OCx and OCxN no output or force idle"]
       Enabled: [1, "OCx and OCxN output enabled"]
+
+_copy:
+  TIM2:
+    from: TIM1
+
+TIM2:
+  _modify:
+    "*":
+      size: 0x10
+    CHCTLR1_Input:
+      name: "CHCTLR1I"
+      displayName: "CHCTLR1I"
+    CHCTLR1_Output:
+      name: "CHCTLR1O"
+      displayName: "CHCTLR1O"
+    CHCTLR2_Input:
+      name: "CHCTLR2I"
+      displayName: "CHCTLR2I"
+    CHCTLR2_Output:
+      name: "CHCTLR2O"
+      displayName: "CHCTLR2O"
+
+  CTLR1:
+    _modify:
+      URS,DIR,CMS,CKD:
+        _write_constraint: "enum"
+
+    CEN:
+      Disabled: [0, "Counter disabled"]
+      Enabled: [1, "Counter enabled"]
+
+    UDIS:
+      Enabled: [0, "UEV enabled"]
+      Disabled: [1, "UEV disabled"]
+
+    URS:
+      Multiple: [0, "Multiple source for update event"]
+      Overflow: [1, "Only overflow can trigger update event"]
+
+    OPM:
+      Disabled: [0, "One pulse mode disabled"]
+      Enabled: [1, "One pulse mode enabled"]
+
+    DIR:
+      Decrement: [0, "Decrement counter"]
+      Increment: [1, "Increment counter"]
+
+    CMS:
+      Edge: [0, "Counter increment or dicrement according to DIR"]
+      Center1: [1, "Center alignment mode 1"]
+      Center2: [2, "Center alignment mode 2"]
+      Center3: [3, "Center alignment mode 3"]
+
+    ARPE:
+      Disabled: [0, "Auto reload preset disabled"]
+      Enabled: [1, "Auto reload preset enabled"]
+
+    CKD:
+      Tck: [0, "Tdts = Tck_int"]
+      Tck2: [1, "Tdts = Tck_int * 2"]
+      Tck4: [2, "Tdts = Tck_int * 4"]
+
+  CTLR2:
+    _modify:
+      TI1S,MMS,CCDS,CCUS,CCPC:
+        _write_constraint: "enum"
+
+    CCPC:
+      NotPreloaded: [0, "CCxE CCxNE OCxM not preloaded"]
+      Preloaded: [1, "CCxE CCxNE OCxM preloaded"]
+
+    CCUS:
+      COMOnly: [0, "Only update on COM set"]
+      Multiple: [1, "Update on COM set or TRGI rising edge"]
+
+    CCDS:
+      CHxCVR: [0, "Request DMA on CHxCVR"]
+      Update: [1, "Request DMA on update event"]
+
+    MMS:
+      Reset: [0, "TIMx_EGR register UG bit used as trigger output(TRG0)"]
+      Enable: [1, "CNT_EN bit used as trigger output(TRG0)"]
+      Update: [2, "Update event used as trigger input(TRG0)"]
+      CmpCC1IF: [3, "Trigger output(TRG0) on CC1IF set"]
+      CmpOC1REF: [4, "OC1REF signal used as trigger output(TRG0)"]
+      CmpOC2REF: [5, "OC2REF signal used as trigger output(TRG0)"]
+      CmpOC3REF: [6, "OC3REF signal used as trigger output(TRG0)"]
+      CmpOC4REF: [7, "OC4REF signal used as trigger output(TRG0)"]
+    
+    TI1S:
+      Direct: [0, "TIMx_CH1 connected directly to TI1"]
+      Xor: [1, "TIMx_CH1/2/3 connected to TI1 after xor"]
+
+  SMCFGR:
+    _modify:
+      SMS,TS,MSM,ETF,ETPS,ETP:
+        _write_constraint: "enum"
+
+    SMS:
+      Internal: [0, "Core counter driven by CK_INT"]
+      Encoder1: [1, "Core counter increment or decrement on TI1FP1 edge with respect to TI2FP2"]
+      Encoder2: [2, "Core counter increment or decrement on TI2FP2 edge with respect to TI1FP1"]
+      Encoder3: [3, "Core counter increment or decrement on TI1FP1/TI2FP2 edge with respect to another signal"]
+      Reset: [4, "Rising edge on TRGI will reset the counter"]
+      Gate: [5, "Counter clock start/stop with respect to TRGI"]
+      Trigger: [6, "Counter start on TRGI rising edge"]
+      External: [7, "Counter driven by TRGI rising edge"]
+
+    TS:
+      Internal0: [0, "ITR0 as trigger"]
+      Internal1: [1, "ITR1 as trigger"]
+      Internal2: [2, "ITR2 as trigger"]
+      Internal3: [3, "ITR3 as trigger"]
+      TI1Edge: [4, "TI1 edge dector"]
+      TI1FP1: [5, "Filtered timer input 1"]
+      TI2FP2: [6, "Filtered timer input 2"]
+      External: [7, "External trigger input"]
+
+    MSM:
+      NoEffect: [0, "No effect"]
+      TRGIDelayed: [1, "Trigger event on TRGI delayed"]
+
+    ETF:
+      NoFilter: [0, "No filter applied, sampling using Fdts"]
+      FckN2: [1, "Fsampling = Fck_int, N=2"]
+      FckN4: [2, "Fsampling = Fck_int, N=4"]
+      FckN8: [3, "Fsampling = Fck_int, N=8"]
+      Fdts2N6: [4, "Fsampling = Fdts / 2, N=6"]
+      Fdts2N8: [5, "Fsampling = Fdts / 2, N=8"]
+      Fdts4N6: [6, "Fsampling = Fdts / 4, N=6"]
+      Fdts4N8: [7, "Fsampling = Fdts / 4, N=8"]
+      Fdts8N6: [8, "Fsampling = Fdts / 8, N=6"]
+      Fdts8N8: [9, "Fsampling = Fdts / 8, N=8"]
+      Fdts16N5: [10, "Fsampling = Fdts / 16, N=5"]
+      Fdts16N6: [11, "Fsampling = Fdts / 16, N=6"]
+      Fdts16N8: [12, "Fsampling = Fdts / 16, N=8"]
+      Fdts32N5: [13, "Fsampling = Fdts / 32, N=5"]
+      Fdts32N6: [14, "Fsampling = Fdts / 32, N=6"]
+      Fdts32N8: [15, "Fsampling = Fdts / 32, N=8"]
+
+    ETPS:
+      "Off": [0, "Pre-division off"]
+      Div2: [1, "ETRP / 2"]
+      Div4: [2, "ETRP / 4"]
+      Div8: [3, "ETRP / 8"]
+
+    ECE:
+      Disabled: [0, "External Clock Mode 2 disabled"]
+      Enabled: [1, "External Clock Mode 2 enabled"]
+
+    ETP:
+      Direct: [0, "Trigger on ETR high voltage or rising edge"]
+      Inversed: [1, "Trigger on ETR low voltage or falling edge"]
+
+  DMAINTENR:
+    "*IE":
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+    "*DE":
+      Disabled: [0, "DMA disabled"]
+      Enabled: [1, "DMA enabled"]
+
+  INTFR:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
+    "*IF":
+      _write:
+        Clear: [0, "Clear interrupt flag"]
+      _read:
+        NotInterrupted: [0, "Not interrupted"]
+        Interrupted: [1, "Interrupted"]
+
+    "*OF":
+      _write:
+        Clear: [0, "Clear overcapture flag"]
+      _read:
+        NotOvercaptured: [0, "Not overcaptured"]
+        Overcaptured: [1, "Overcaptured"]
+
+  SWEVGR:
+    "*":
+      _write:
+        Generate: [1, "Generate event"]
+
+  # FIXME: CHCTLR1O/CHCTLR1I, CHCTLR2O/CHCTLR2I share the same address. Will this mess up with the ownership?
+  CHCTLR1O:
+    _modify:
+      CC?S,OC?M:
+        _write_constraint: "enum"
+
+    # FIXME: RM completely a mess here, need to verify
+    CC1S:
+      Input: [0, "CC1 configured as input"]
+      OutputTI1: [1, "CC1 configured as output. IC1 mapped to TI1"]
+      OutputTI2: [2, "CC1 configured as output. IC1 mapped to TI2"]
+      OutputTRC: [3, "CC1 configured as output. IC1 mapped to TRC"]
+
+    CC2S:
+      Input: [0, "CC2 configured as input"]
+      OutputTI2: [1, "CC2 configured as output. IC2 mapped to TI2"]
+      OutputTI1: [2, "CC2 configured as output. IC2 mapped to TI1"]
+      OutputTRC: [3, "CC2 configured as output. IC2 mapped to TRC"]
+
+    OC?FE:
+      Disabled: [0, "Fast enabling disabled"]
+      Enabled: [1, "Fast enabling enabled"] 
+
+    OC?PE:
+      Disabled: [0, "Preloading disabled"]
+      Enabled: [1, "Preloading enabled"]
+
+    OC1M:
+      Frozen: [0, "No effect on OC1REF"]
+      ForceHighCmp: [1, "OC1REF high when core counter = compare capture register"]
+      ForceLowCmp: [2, "OC1REF low when core counter = compare capture register"]
+      FlipCmp: [3, "OC1REF flipped when core counter = compare capture register"]
+      ForceLow: [4, "OC1REF set low"]
+      ForceHigh: [5, "OC1REF set high"]
+      PWM1: [6, "Before low after high"] # FIXME: PWM1/2 need better description
+      PWM2: [7, "Before high after low"]
+
+    OC2M:
+      Frozen: [0, "No effect on OC2REF"]
+      ForceHighCmp: [1, "OC2REF high when core counter = compare capture register"]
+      ForceLowCmp: [2, "OC2REF low when core counter = compare capture register"]
+      FlipCmp: [3, "OC2REF flipped when core counter = compare capture register"]
+      ForceLow: [4, "OC2REF set low"]
+      ForceHigh: [5, "OC2REF set high"]
+      PWM1: [6, "Before low after high"] # FIXME: PWM1/2 need better description
+      PWM2: [7, "Before high after low"]
+
+    OC?CE:
+      Disabled: [0, "OCxREF reset on ETRF disabled"]
+      Enabled: [1, "OCxREF reset on ETRF enabled"]
+  
+  CHCTLR1I:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
+    CC1S:
+      Output: [0, "CC1 configured as output"]
+      InputTI1: [1, "CC1 configured as input. IC1 mapped to TI1"]
+      InputTI2: [2, "CC1 configured as input. IC1 mapped to TI2"]
+      InputTRC: [3, "CC1 configured as input. IC1 mapped to TRC"]
+
+    CC2S:
+      Output: [0, "CC2 configured as output"]
+      InputTI2: [1, "CC2 configured as input. IC2 mapped to TI2"]
+      InputTI1: [2, "CC2 configured as input. IC2 mapped to TI1"]
+      InputTRC: [3, "CC2 configured as input. IC2 mapped to TRC"]
+
+    IC?PSC:
+      NoDiv: [0, "Every capture input edge will trigger a capture"]
+      Div2: [1, "Every 2 capture input edges will trigger a capture"]
+      Div4: [2, "Every 4 capture input edges will trigger a capture"]
+      Div8: [3, "Every 8 capture input edges will trigger a capture"]
+
+    IC?F:
+      NoFilter: [0, "No filter applied. Sampling using Fdts"]
+      FckN2: [1, "Fsampling = Fck_int, N=2"]
+      FckN4: [2, "Fsampling = Fck_int, N=4"]
+      FckN8: [3, "Fsampling = Fck_int, N=8"]
+      Fdts2N6: [4, "Fsampling = Fdts / 2, N=6"]
+      Fdts2N8: [5, "Fsampling = Fdts / 2, N=8"]
+      Fdts4N6: [6, "Fsampling = Fdts / 4, N=6"]
+      Fdts4N8: [7, "Fsampling = Fdts / 4, N=8"]
+      Fdts8N6: [8, "Fsampling = Fdts / 8, N=6"]
+      Fdts8N8: [9, "Fsampling = Fdts / 8, N=8"]
+      Fdts16N5: [10, "Fsampling = Fdts / 16, N=5"]
+      Fdts16N6: [11, "Fsampling = Fdts / 16, N=6"]
+      Fdts16N8: [12, "Fsampling = Fdts / 16, N=8"]
+      Fdts32N5: [13, "Fsampling = Fdts / 32, N=5"]
+      Fdts32N6: [14, "Fsampling = Fdts / 32, N=6"]
+      Fdts32N8: [15, "Fsampling = Fdts / 32, N=8"]
+
+  # FIXME: all modification applied to CHCTLR1I/O should be applied correspondingly to CHCTLR2I/O
+  CHCTLR2O:
+    _modify:
+      CC?S,OC?M:
+        _write_constraint: "enum"
+
+    CC3S:
+      Input: [0, "CC3 configured as input"]
+      OutputTI1: [1, "CC3 configured as output. IC3 mapped to TI1"]
+      OutputTI2: [2, "CC3 configured as output. IC3 mapped to TI2"]
+      OutputTRC: [3, "CC3 configured as output. IC3 mapped to TRC"]
+
+    CC4S:
+      Input: [0, "CC4 configured as input"]
+      OutputTI2: [1, "CC4 configured as output. IC4 mapped to TI2"]
+      OutputTI1: [2, "CC4 configured as output. IC4 mapped to TI1"]
+      OutputTRC: [3, "CC4 configured as output. IC4 mapped to TRC"]
+
+    OC?FE:
+      Disabled: [0, "Fast enabling disabled"]
+      Enabled: [1, "Fast enabling enabled"] 
+
+    OC?PE:
+      Disabled: [0, "Preloading disabled"]
+      Enabled: [1, "Preloading enabled"]
+
+    OC3M:
+      Frozen: [0, "No effect on OC3REF"]
+      ForceHighCmp: [1, "OC3REF high when core counter = compare capture register"]
+      ForceLowCmp: [2, "OC3REF low when core counter = compare capture register"]
+      FlipCmp: [3, "OC3REF flipped when core counter = compare capture register"]
+      ForceLow: [4, "OC3REF set low"]
+      ForceHigh: [5, "OC3REF set high"]
+      PWM1: [6, "Before low after high"] # FIXME: PWM1/2 need better description
+      PWM2: [7, "Before high after low"]
+
+    OC4M:
+      Frozen: [0, "No effect on OC4REF"]
+      ForceHighCmp: [1, "OC4REF high when core counter = compare capture register"]
+      ForceLowCmp: [2, "OC4REF low when core counter = compare capture register"]
+      FlipCmp: [3, "OC4REF flipped when core counter = compare capture register"]
+      ForceLow: [4, "OC4REF set low"]
+      ForceHigh: [5, "OC4REF set high"]
+      PWM1: [6, "Before low after high"] # FIXME: PWM1/2 need better description
+      PWM2: [7, "Before high after low"]
+
+    OC?CE:
+      Disabled: [0, "OCxREF reset on ETRF disabled"]
+      Enabled: [1, "OCxREF reset on ETRF enabled"]
+  
+  CHCTLR2I:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
+    CC3S:
+      Output: [0, "CC3 configured as output"]
+      InputTI1: [1, "CC3 configured as input. IC3 mapped to TI1"]
+      InputTI2: [2, "CC3 configured as input. IC3 mapped to TI2"]
+      InputTRC: [3, "CC3 configured as input. IC3 mapped to TRC"]
+
+    CC4S:
+      Output: [0, "CC4 configured as output"]
+      InputTI2: [1, "CC4 configured as input. IC4 mapped to TI2"]
+      InputTI1: [2, "CC4 configured as input. IC4 mapped to TI1"]
+      InputTRC: [3, "CC4 configured as input. IC4 mapped to TRC"]
+
+    IC?PSC:
+      NoDiv: [0, "Every capture input edge will trigger a capture"]
+      Div2: [1, "Every 2 capture input edges will trigger a capture"]
+      Div4: [2, "Every 4 capture input edges will trigger a capture"]
+      Div8: [3, "Every 8 capture input edges will trigger a capture"]
+
+    IC?F:
+      NoFilter: [0, "No filter applied. Sampling using Fdts"]
+      FckN2: [1, "Fsampling = Fck_int, N=2"]
+      FckN4: [2, "Fsampling = Fck_int, N=4"]
+      FckN8: [3, "Fsampling = Fck_int, N=8"]
+      Fdts2N6: [4, "Fsampling = Fdts / 2, N=6"]
+      Fdts2N8: [5, "Fsampling = Fdts / 2, N=8"]
+      Fdts4N6: [6, "Fsampling = Fdts / 4, N=6"]
+      Fdts4N8: [7, "Fsampling = Fdts / 4, N=8"]
+      Fdts8N6: [8, "Fsampling = Fdts / 8, N=6"]
+      Fdts8N8: [9, "Fsampling = Fdts / 8, N=8"]
+      Fdts16N5: [10, "Fsampling = Fdts / 16, N=5"]
+      Fdts16N6: [11, "Fsampling = Fdts / 16, N=6"]
+      Fdts16N8: [12, "Fsampling = Fdts / 16, N=8"]
+      Fdts32N5: [13, "Fsampling = Fdts / 32, N=5"]
+      Fdts32N6: [14, "Fsampling = Fdts / 32, N=6"]
+      Fdts32N8: [15, "Fsampling = Fdts / 32, N=8"]
+
+  # CCER:
+    # TODO: not documented, need discussion

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -155,8 +155,8 @@ RCC:
         Interrupted: [1, "Interrupt occurred"]
 
     "*IE":
-      Disable: [0, "Disable ready interrupt"]
-      Enable: [1, "Enable ready interrupt"]
+      Disabled: [0, "Ready interrupt disabled"]
+      Enabled: [1, "Ready interrupt enabled"]
 
     
     "*C":
@@ -164,14 +164,18 @@ RCC:
         Clear: [1, "Clear interrupt flag"]
 
   APB?PRSTR,AHBRSTR:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
     "*":
       _write:
         Reset: [1, "Reset peripheral"]
 
   AHBPCENR,APB?PCENR:
     "*":
-      Disable: [0, "Disable module"]
-      Enable: [1, "Enable module"]
+      Disable: [0, "Module disabled"]
+      Enabled: [1, "Module enabled"]
 
   BDCTLR:
     _modify:
@@ -198,8 +202,8 @@ RCC:
       HSE: [3, "HSE divided by 128 as RTC clock source"]
 
     RTCEN:
-      Disable: [0, "Disable RTC"]
-      Enable: [1, "Enable RTC"]
+      Disabled: [0, "RTC disabled"]
+      Enabled: [1, "RTC enabled"]
 
     BDRST:
       Cancel: [0, "Cancel back domain reset"]
@@ -230,13 +234,17 @@ RCC:
     
 EXTEND:
   EXTEND_CTR:
+    _modify:
+      USBDLS,USBHDIO,USB5VSEL,HSIPRE,LKUPRESET,LDOTRIM:
+        _write_constraint: "enum"
+
     USBDLS:
       FullSpeed: [0, "USBD full speed"]
       LowSpeed: [1, "USBD low speed"]
 
     USBDPU:
-      Disable: [0, "Disable USBD internal pull-up resistor"]
-      Enable: [1, "Enable USBD internal pull-up resistor"]
+      Disabled: [0, "USBD internal pull-up resistor disabled"]
+      Enabled: [1, "USBD internal pull-up resistor enabled"]
 
     USBHDIO:
       Other: [0, "Use PB6/PB7 as other functions"]
@@ -251,8 +259,8 @@ EXTEND:
       NoDiv: [1, "HSI directly as PLL clock source"]
 
     LKUPEN:
-      Disable: [0, "Disable lock-up reset"]
-      Enable: [1, "Enable lock-up reset"]
+      Disabled: [0, "Lock-up reset disabled"]
+      Enabled: [1, "Lock-up reset enabled"]
 
     LKUPRESET:
       _read:
@@ -271,19 +279,27 @@ BKP:
       size: 0x10
 
   OCTLR:
+    _modify:
+      ASOS:
+        _write_constraint: "enum"
+
     CCO:
       Disable: [0, "No calibration clock output"]
       RTCDiv64: [1, "TAMPER output RTC divided by 64"]
 
     ASOE:
-      Enable: [0, "Enable TAMPER pulse output"]
-      Disable: [1, "Disable TAMPER pulse output"]
+      Enabled: [0, "TAMPER pulse output enabled"]
+      Disabled: [1, "TAMPER pulse output disabled"]
 
     ASOS:
       Alarm: [0, "Output alarm pulse"]
       Second: [1, "Output second pulse"]
 
   TPCTLR:
+    _modify:
+      TPE,TPAL:
+        _write_constraint: "enum"
+
     TPE:
       GPIO: [0, "TAMPER pin as GPIO"]
       TAMPER: [1, "TAMPER pin as tamper detection"]
@@ -306,8 +322,8 @@ BKP:
         Clear: [1, "Clear tamper interrupt flag"]
 
     TPIE:
-      Disable: [0, "Disable tamper interrupt"]
-      Enable: [1, "Enable tamper interrupt"]
+      Disabled: [0, "Tamper interrupt disabled"]
+      Enabled: [1, "Tamper interrupt enabled"]
 
     TEF:
       _read:
@@ -339,12 +355,12 @@ RTC:
 
   CTLRH:
     "*E":
-      Disable: [0, "Disable interrupt"]
-      Enable: [1, "Enable interrupt"]
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
 
   CTLRL:
     _modify:
-      SECF,ALRF,OWF,RSF:
+      SECF,ALRF,OWF,RSF,RTOFF:
         _write_constraint: "enum"
 
     SECF,ALRF,OWF:
@@ -460,28 +476,28 @@ EXTI:
 
   INTENR:
     "MR*":
-      Disable: [0, "Disable interrupt on this line"]
-      Enable: [1, "Enable interrupt on this line"]
+      Disable: [0, "Interrupt on this line disabled"]
+      Enabled: [1, "Interrupt on this line enabled"]
 
   EVENR:
     "MR*":
-      Disable: [0, "Disable interrupt event on this line"]
-      Enable: [1, "Enable interrupt event on this line"]
+      Disabled: [0, "Interrupt event on this line disabled"]
+      Enabled: [1, "Interrupt event on this line enabled"]
 
   RTENR:
     "TR*":
-      Disable: [0, "Disable rising edge trigger on this line"]
-      Enable: [1, "Enable rising edge trigger on this line"]
+      Disabled: [0, "Rising edge trigger on this line disabled"]
+      Enabled: [1, "Rising edge trigger on this line enabled"]
 
   FTENR:
     "TR*":
-      Disable: [0, "Disable falling edge trigger on this line"]
-      Enable: [1, "Enable falling edge trigger on this line"]
+      Disabled: [0, "Falling edge trigger on this line disabled"]
+      Enabled: [1, "Falling edge trigger on this line enabled"]
 
   SWIEVR:
     "SWIER*":
-      Reset: [0, "Reset software interrupt on this line"]
-      Trigger: [1, "Trigger software interrupt on this line"]
+      Reset: [0, "Software interrupt on this line reset"]
+      Triggerred: [1, "Software interrupt on this line triggerred"]
 
   INTFR:
     _merge:
@@ -491,6 +507,10 @@ EXTI:
       IF:
         name: IF%s
         description: Interrupt flag on line %s
+
+    _modify:
+      "IF*":
+        _write_constraint: "enum"
 
     "IF*":
       _write:
@@ -506,12 +526,12 @@ PFIC:
         _write_constraint: "enum"
 
     HWSTKCTRL:
-      Enable: [0, "Enable hardware stack"]
-      Disable: [1, "Disable hardware stack"]
+      Enabled: [0, "Hardware stack enabled"]
+      Disabled: [1, "Hardware stack disabled"]
 
     NESTCTRL:
-      Enable: [0, "Enable interrupt nesting"]
-      Disable: [1, "Disable interrupt nesting"]
+      Enabled: [0, "Interrupt nesting enabled"]
+      Disabled: [1, "Interrupt nesting disabled"]
 
     NMISET,EXCSET:
       _write:
@@ -545,6 +565,10 @@ PFIC:
         HasPendingInterrupt: [1, "Has interrupt pending"]
 
   SCTLR:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
     SLEEPONEXIT:
       Continue: [0, "Don't sleep after exiting interrupt service"]
       Sleep: [1, "Enter sleep mode after exiting interrupt service"]
@@ -555,7 +579,7 @@ PFIC:
 
     WFITOWFE:
       Normal: [0, "Nothing"]
-      Enable: [1, "WFI will be treated as WFE"]
+      Enabled: [1, "WFI is treated as WFE"]
 
     SEVONPEND:
       OnlyEnabled: [0, "Only enabled events and interrupts can wake up the system"]
@@ -582,7 +606,7 @@ _add:
         resetValue: 0x00000000
         fields:
           STE:
-            description: Enable SysTick
+            description: SysTick enable state
             bitOffset: 0
             bitWidth: 1
       CNTL:
@@ -625,3 +649,428 @@ _add:
             description: SysTick compare high bits
             bitOffset: 0
             bitWidth: 32
+
+SYSTICK:
+  CTLR:
+    STE:
+      Disabled: [0, "SysTick counter disabled"]
+      Enabled: [1, "SysTick counter enabled"]
+
+"GPIO*":
+  CFG?R:
+    _modify:
+      MODE?,CNF?:
+        _write_constraint: "enum"
+
+    MODE?:
+      Input: [0, "Pin used as input"]
+      Output: [1, "Pin used as output with max speed 10MHz"]
+      LowSpeed: [2, "Pin used as output with max speed 2MHz"]
+      HighSpeed: [3, "Pin used as output with max speed 50MHz"]
+
+    CNF?:
+      AInputPPOutput: [0, "Analog input or general purpose push-pull output"]
+      FInputODOutput: [1, "Float input or general purpose open drain output"]
+      PUDInputAlternatePPOutput: [2, "Pull up pull down input or alternate function push-pull output"]
+      AlternateODOutput: [3, "Alternate function open drain output"]
+
+  BSHR:
+    _modify:
+      "BS*,BR*":
+        _write_constraint: "enum"
+
+    "BS*":
+      _write:
+        Set: [1, "Set output bit"]
+
+    "BR*":
+      _write:
+        Reset: [1, "Reset output bit"]
+
+  BCR:
+    _modify:
+      "BR*":
+        _write_constraint: "enum"
+
+    "BR*":
+      _write:
+        Reset: [1, "Reset output bit"]
+
+  LCKR:
+    _modify:
+      LCK0,LCK1,LCK2,LCK3,LCK4,LCK5,LCK6,LCK7,LCK8,LCK9,LCK10,LCK11,LCK12,LCK13,LCK14,LCK15:
+        _write_constraint: "enum"
+
+    LCK0,LCK1,LCK2,LCK3,LCK4,LCK5,LCK6,LCK7,LCK8,LCK9,LCK10,LCK11,LCK12,LCK13,LCK14,LCK15:
+      _write:
+        Lock: [1, "Lock the port"]
+
+    LCKK:
+      _read:
+        Unlocked: [0, "Not locked"]
+        Locked: [1, "Locked"]
+
+AFIO:
+  _delete:
+    - PCFR?
+
+  _add:
+    PCFR:
+      displayName: PCFR
+      description: AF remap and debug I/O configuration register (AFIO_PCFR)
+      addressOffset: 0x4
+      size: 0x20
+      resetValue: 0x00000000
+      fields:
+        SPI1RM:
+          description: SPI1 remapping
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write
+        I2C1RM:
+          description: I2C1 remapping
+          bitOffset: 1
+          bitWidth: 1
+          access: read-write
+        USART1RM:
+          description: USART1 remapping
+          bitOffset: 2
+          bitWidth: 1
+          access: read-write
+        USART2RM:
+          description: USART2 remapping
+          bitOffset: 3
+          bitWidth: 1
+          access: read-write
+        USART3RM:
+          description: USART3 remapping
+          bitOffset: 4
+          bitWidth: 2
+          access: read-write
+        TIM1RM:
+          description: TIM1 remapping
+          bitOffset: 6
+          bitWidth: 2
+          access: read-write
+        TIM2RM:
+          description: TIM2 remapping
+          bitOffset: 8
+          bitWidth: 2
+          access: read-write
+        TIM3RM:
+          description: TIM3 remapping
+          bitOffset: 10
+          bitWidth: 2
+          access: read-write
+        CANRM:
+          description: CAN remapping
+          bitOffset: 13
+          bitWidth: 2
+          access: read-write
+        PD01RM:
+          description: PD01 remapping
+          bitOffset: 15
+          bitWidth: 1
+          access: read-write
+        SWCFG:
+          description: RVSWD configuration
+          bitOffset: 24
+          bitWidth: 3
+          access: write-only
+        
+  ECR:
+    _modify:
+      PORT:
+        _write_constraint: "enum"
+
+    PORT:
+      PA: [0, "Event out to PA port"]
+      PB: [1, "Event out to PB port"]
+      PC: [2, "Event out to PC port"]
+      PD: [3, "Event out to PD port"]
+
+    EVOE:
+      Disabled: [0, "Event out disabled"]
+      Enable: [1, "Event out enabled"]
+
+  PCFR:
+    _modify:
+      USART3RM,TIM1RM,TIM2RM,TIM3RM,CANRM,SWCFG:
+        _write_constraint: "enum"
+
+    SPI1RM,I2C1RM,USART1RM,USART2RM,PD01RM:
+      Default: [0, "Default"]
+      Remapped: [1, "Remapped"]
+
+    USART3RM,TIM1RM:
+      Default: [0, "Default"]
+      PartiallyRemapped: [1, "Partially remapped"]
+      Remapped: [3, "Remapped"]
+
+    TIM2RM:
+      Default: [0, "Default"]
+      PartiallyRemapping1: [1, "Partially remapping case 1"]
+      PartiallyRemapping2: [2, "Partially remapping case 2"]
+      Remapped: [3, "Remapped"]
+
+    TIM3RM:
+      Default: [0, "Default"]
+      PartiallyRemapped: [2, "Partially remapped"]
+      Remapped: [3, "Remapped"]
+
+    CANRM:
+      PA: [0, "CAN mapped to port PA"]
+      PB: [1, "CAN mapped to port PB"]
+
+    SWCFG:
+      _write:
+        Enabled: [0, "SWD enabled"]
+        Disabled: [4, "SWD disabled"]
+
+DMA:
+  INTFR:
+    GIF?:
+      _read:
+        NoInterrupt: [0, "No TEI HTI or TCI occurred"]
+        HasInterrupt: [1, "TEI HTI or TCI occurred"]
+    
+    TCIF?:
+      _read:
+        NoEvent: [0, "No transfer complete event occurred"]
+        HasEvent: [1, "Transfer complete event occurred"]
+
+    HTIF?:
+      _read:
+        NoEvent: [0, "No transfer half event occurred"]
+        HasEvent: [1, "Transfer half event occurred"]
+    
+    TEIF?:
+      _read:
+        NoEvent: [0, "No transfer error event occurred"]
+        HasEvent: [1, "Transfer error event occurred"]
+
+  INTFCR:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+
+    "*":
+      Clear: [1, "Clear the flag"]
+
+  CFGR?:
+    _modify:
+      PSIZE,MSIZE,PL:
+        _write_constraint: "enum"
+
+    EN:
+      Disabled: [0, "DMA channel disabled"]
+      Enabled: [1, "DMA channel enabled"]
+
+    TCIE,HTIE,TEIE:
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+
+    DIR:
+      Peripheral: [0, "Read from peripheral"]
+      Memory: [1, "Read from memory"]
+
+    CIRC:
+      Once: [0, "Only execute once"]
+      Circulate: [1, "Circulation enabled"]
+
+    PINC:
+      Disabled: [0, "Peripheral address increment disabled"]
+      Enabled: [1, "Peripheral address increment enabled"]
+
+    MINC:
+      Disabled: [0, "Memory address increment disabled"]
+      Enabled: [1, "Memory address increment enabled"]
+
+    PSIZE:
+      B8: [0, "Peripheral address width is 8-bit"]
+      B16: [1, "Peripheral address width is 16-bit"]
+      B32: [2, "Peripheral address width is 32-bit"]
+
+    MSIZE:
+      B8: [0, "Memory address width is 8-bit"]
+      B16: [1, "Memory address width is 16-bit"]
+      B32: [2, "Memory address width is 32-bit"]
+
+    PL:
+      Low: [0, "Channel priority low"]
+      Mid: [1, "Channel priority mid"]
+      High: [2, "Channel priority high"]
+      Highest: [3, "Channel priority highest"]
+
+    MEM2MEM:
+      Disabled: [0, "Memory to memory transfer disabled"]
+      Enabled: [1, "Memory to memory transfer enabled"]
+
+ADC:
+  STATR:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+      JEOC:
+        name: "IEOC"
+      JSTRT:
+        name: "ISTRT"
+      STRT:
+        name: "RSTRT"
+
+    AWD:
+      _read:
+        NoEvent: [0, "No analog watch dog event occurred"]
+        HasEvent: [1, "Analog watch dog event occurred"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    EOC,IEOC:
+      _read:
+        InProgress: [0, "Conversion in progress"]
+        Completed: [1, "Conversion completed"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+    ISTRT,RSTRT:
+      _read:
+        Idle: [0, "Conversion not started"]
+        Started: [1, "Conversion started"]
+      _write:
+        Clear: [0, "Clear this flag"]
+
+  CTLR1:
+    _delete:
+      - DUALMOD
+
+    _modify:
+      JEOCIE:
+        name: "IEOCIE"
+      JAUTO:
+        name: "IAUTO"
+      JDISCEN:
+        name: "IDISCEN"
+      JAWDEN:
+        name: "IAWDEN"
+
+    "*IE":
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+
+    SCAN:
+      Disabled: [0, "Scan mode disabled"]
+      Enabled: [1, "Scan mode enabled"]
+
+    AWDSGL:
+      All: [0, "AWDG enabled on all channel in scan mode"]
+      Specific: [1, "AWDG enabled on specific channel in scan mode"]
+
+    IAUTO:
+      Disabled: [0, "Auto injection disabled"]
+      Enabled: [1, "Auto injection enabled"]
+    
+    "?DISCEN":
+      Disabled: [0, "Discontinuous mode disabled"]
+      Enabled: [1, "Discontinuous mode enabled"]
+
+    "?AWDEN":
+      Disabled: [0, "Analog watch dog disabled"]
+      Enabled: [1, "Analog watch dog enabled"]
+
+    TKENABLE:
+      Disabled: [0, "TKEY module disabled"]
+      Enabled: [1, "TKEY module enabled"]
+
+  CTLR2:
+    _modify:
+      JEXTSEL:
+        name: "IEXTSEL"
+      JEXTTRIG:
+        name: "IEXTTRIG"
+      JSWSTART:
+        name: "ISWSTART"
+      EXTSEL:
+        name: "REXTSEL"
+      EXTTRIG:
+        name: "REXTTRIG"
+      SWSTART:
+        name: "RSWSTART"
+      CAL,RSTCAL,ALIGN,IEXTSEL,REXTSEL:
+        _write_constraint: "enum"
+
+    ADON:
+      Disabled: [0, "ADC disabled"]
+      Enabled: [1, "ADC enabled and proceed conversion"]
+
+    CONT:
+      Disabled: [0, "Continuous conversion disabled"]
+      Enabled: [1, "Continuous conversion enabled"]
+
+    CAL:
+      _write:
+        Calibrate: [1, "Start calibration"]
+      _read:
+        Done: [0, "Calibration done"]
+        Calibrating: [1, "Calibration in progress"]
+
+    RSTCAL:
+      _write:
+        Reset: [1, "Reset calibration"]
+      _read:
+        Done: [0, "Reset done"]
+        Resetting: [1, "Reset in progress"]
+
+    DMA:
+      Disabled: [0, "DMA mode disabled"]
+      Enabled: [1, "DMA mode enabled"]
+
+    ALIGN:
+      Right: [0, "Right alignment"]
+      Left: [1, "Left alignment"]
+
+    IEXTSEL:
+      TIM1TRG0: [0, "TIM1 TRG0 event"]
+      TIM1CC4: [1, "TIM1 CC4 event"]
+      TIM2TRG0: [2, "TIM2 TRG0 event"]
+      TIM2CC1: [3, "TIM2 CC1 event"]
+      TIM3CC4: [4, "TIM3 CC4 event"]
+      TIM4TRG0: [5, "TIM4 TRG0 event"]
+      EXTI15: [6, "EXTI line 15"]
+      ISWSTART: [7, "Software trigger"]
+
+    IEXTTRIG:
+      Disabled: [0, "External event trigger disabled"]
+      Enabled: [1, "External event trigger enabled"]
+
+    REXTSEL:
+      TIM1CC1: [0, "TIM1 CC1 event"]
+      TIM1CC2: [1, "TIM1 CC2 event"]
+      TIM1CC3: [2, "TIM1 CC4 event"]
+      TIM2CC2: [3, "TIM2 CC2 event"]
+      TIM3TRG0: [4, "TIM3 TRG0 event"]
+      TIM4CC4: [5, "TIM4 CC4 event"]
+      EXTI11: [6, "EXTI line 11"]
+      RSWSTART: [7, "Software trigger"]
+
+    REXTTRIG:
+      Disabled: [0, "External event trigger disabled"]
+      Enabled: [1, "External event trigger enabled"]
+
+    ISWSTART,RSWSTART:
+      Reset: [0, "Reset state"]
+      Start: [1, "Start conversion"]
+
+    TSVREFE:
+      Disabled: [0, "Temperature and internal voltage channel disabled"]
+      Enabled: [1, "Temperature and internal voltage channel enabled"]
+
+  SAMPTR?:
+    "SMP*":
+      T1P5: [0, "1.5T sampling rate"]
+      T7P5: [1, "7.5T sampling rate"]
+      T13P5: [2, "13.5T sampling rate"]
+      T28P5: [3, "28.5T sampling rate"]
+      T41P5: [4, "41.5T sampling rate"]
+      T55P5: [5, "55.5T sampling rate"]
+      T71P5: [6, "71.5T sampling rate"]
+      T239P5: [7, "239.5T sampling rate"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -264,3 +264,234 @@ EXTEND:
     LDOTRIM:
       LDO1V5: [0, "LDO output 1.5V"]
       LDO1V62: [1, "LDO output 1.62V"]
+
+BKP:
+  _modify:
+    "*":
+      size: 0x10
+
+  OCTLR:
+    CCO:
+      Disable: [0, "No calibration clock output"]
+      RTCDiv64: [1, "TAMPER output RTC divided by 64"]
+
+    ASOE:
+      Enable: [0, "Enable TAMPER pulse output"]
+      Disable: [1, "Disable TAMPER pulse output"]
+
+    ASOS:
+      Alarm: [0, "Output alarm pulse"]
+      Second: [1, "Output second pulse"]
+
+  TPCTLR:
+    TPE:
+      GPIO: [0, "TAMPER pin as GPIO"]
+      TAMPER: [1, "TAMPER pin as tamper detection"]
+    
+    TPAL:
+      High: [0, "High voltage level will clear all backup registers"]
+      Low: [1, "Low voltage level will clear all backup registers"]
+
+  TPCSR:
+    _modify:
+      CTE,CTI:
+        _write_constraint: "enum"
+
+    CTE:
+      _write:
+        Clear: [1, "Clear tamper event flag"]
+
+    CTI:
+      _write:
+        Clear: [1, "Clear tamper interrupt flag"]
+
+    TPIE:
+      Disable: [0, "Disable tamper interrupt"]
+      Enable: [1, "Enable tamper interrupt"]
+
+    TEF:
+      _read:
+        NotTampered: [0, "Tamper event not occurred"]
+        Tampered: [1, "Tamper event occurred"]
+
+    TIF:
+      _read:
+        NotInterrupted: [0, "Tamper not interrupted"]
+        Interrupted: [1, "Tamper interrupted"]
+
+CRC:
+  _modify:
+    IDATAR:
+      size: 0x8
+
+  CTLR:
+    _modify:
+      RST:
+        _write_constraint: "enum"
+    RST:
+      _write:
+        Reset: [1, "Reset CRC"]
+
+RTC:
+  _modify:
+    "*":
+      size: 0x10
+
+  CTLRH:
+    "*E":
+      Disable: [0, "Disable interrupt"]
+      Enable: [1, "Enable interrupt"]
+
+  CTLRL:
+    _modify:
+      SECF,ALRF,OWF,RSF:
+        _write_constraint: "enum"
+
+    SECF,ALRF,OWF:
+      _read:
+        NoEvent: [0, "No event occurred"]
+        HasEvent: [1, "Event occurred"]
+      _write:
+        Clear: [0, "Clear event flag"]
+
+    RSF:
+      _read:
+        NotSynchronized: [0, "Registers not synchronized"]
+        Synchronized: [1, "Registers synchronized"]
+      _write:
+        Reset: [0, "Reset synchronization state"]
+
+    CNF:
+      Exit: [0, "Exit configuration mode and write"]
+      Enter: [1, "Enter configuration mode"]
+    
+    RTOFF:
+      InProgress: [0, "RTC operation in progress"]
+      Done: [1, "RTC operation done"]
+
+IWDG:
+  _modify:
+    "*":
+      size: 0x10
+
+  CTLR:
+    _modify:
+      KEY:
+        _write_constraint: "enum"
+
+    KEY:
+      Feed: [0xAAAA, "Load IWDG_RLDR register to IWDG counter"]
+      Modify: [0x5555, "Enable modifying IWDG_PSCR and IWDG_RLDR"]
+      Launch: [0xCCCC, "Launch watch dog"]
+
+  PSCR:
+    _modify:
+      PR:
+        name: "PSCR"
+        _write_constraint: "enum"
+
+    PSCR:
+      Div4: [0, "IWDG Clock = LSI / 4"]
+      Div8: [1, "IWDG Clock = LSI / 8"]
+      Div16: [2, "IWDG Clock = LSI / 16"]
+      Div32: [3, "IWDG Clock = LSI / 32"]
+      Div64: [4, "IWDG Clock = LSI / 64"]
+      Div128: [5, "IWDG Clock = LSI / 128"]
+      Div256: [6, "IWDG Clock = LSI / 256"]
+
+  STATR:
+    RUV,PVU:
+      _read:
+        Done: [0, "Update done"]
+        Updating: [1, "Updating data"]
+
+WWDG:
+  _modify:
+    "*":
+      size: 0x10
+
+  CTLR:
+    _modify:
+      WDGA:
+        _write_constraint: "enum"
+
+    WDGA:
+      _read:
+        Disabled: [0, "WWDG disabled"]
+        Enabled: [1, "WWDG enabled"]
+      _write:
+        Enable: [1, "Enable WWDG"]
+
+  CFGR:
+    _modify:
+      WDGTB,EWI:
+        _write_constraint: "enum"
+
+    WDGTB:
+      NoDiv: [0, "WWDG Clock = PCLK1 / 4096"]
+      Div2: [1, "WWDG Clock = PCLK1 / 4096 / 2"]
+      Div4: [2, "WWDG Clock = PCLK1 / 4096 / 4"]
+      Div8: [3, "WWDG Clock = PCLK1 / 4096 / 8"]
+
+    EWI:
+      _read:
+        Disabled: [0, "Early wake up interrupt disabled"]
+        Enabled: [1, "Early wake up interrupt enabled"]
+      _write:
+        Enable: [1, "Enable early wake up interrupt"]
+
+
+  STATR:
+    _modify:
+      WEIF:
+        _write_constraint: "enum"
+
+    WEIF:
+      _read:
+        Normal: [0, "No early wake up"]
+        WakenUp: [1, "Early wake up occurred"]
+      _write:
+        Reset: [0, "Reset early wake up flag"]
+
+EXTI:
+  _modify:
+    INTFR:
+      description: "Interrupt flag register (EXTI_INTFR)"
+
+  INTENR:
+    "MR*":
+      Disable: [0, "Disable interrupt on this line"]
+      Enable: [1, "Enable interrupt on this line"]
+
+  EVENR:
+    "MR*":
+      Disable: [0, "Disable interrupt event on this line"]
+      Enable: [1, "Enable interrupt event on this line"]
+
+  RTENR:
+    "TR*":
+      Disable: [0, "Disable rising edge trigger on this line"]
+      Enable: [1, "Enable rising edge trigger on this line"]
+
+  FTENR:
+    "TR*":
+      Disable: [0, "Disable falling edge trigger on this line"]
+      Enable: [1, "Enable falling edge trigger on this line"]
+
+  SWIEVR:
+    "SWIER*":
+      Reset: [0, "Reset software interrupt on this line"]
+      Trigger: [1, "Trigger software interrupt on this line"]
+
+  INTFR:
+    _merge:
+      IF: "PR*"
+
+    _split:
+      IF:
+        name: IF%s
+        description: Interrupt flag on line %s
+
+    "IF*":
+      _write:
+        Reset: [1, "Reset interrupt flag on this line"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -243,8 +243,8 @@ EXTEND:
       USBHD: [1, "Use PB6/PB7 as USBHD function"]
 
     USB5VSEL:
-      3V3: [0, "VDD is 3.3V"]
-      5V: [1, "VDD is 5V"]
+      VDD3V3: [0, "VDD is 3.3V"]
+      VDD5V: [1, "VDD is 5V"]
 
     HSIPRE:
       Div2: [0, "HSI divided by 2 as PLL clock source"]
@@ -262,5 +262,5 @@ EXTEND:
         Clear: [1, "Clear reset flag"] # ?? CH32xRM says set 1 to clear
 
     LDOTRIM:
-      1V5: [0, "LDO output 1.5V"]
-      1V62: [1, "LDO output 1.62V"]
+      LDO1V5: [0, "LDO output 1.5V"]
+      LDO1V62: [1, "LDO output 1.62V"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -259,7 +259,7 @@ EXTEND:
         Normal: [0, "No lock-up reset occurred"]
         Reset: [1, "Lock-up reset occurred"]
       _write:
-        Clear: [1, "Clear reset flag"] # ?? CH32xRM says set 1 to clear
+        Clear: [1, "Clear reset flag"]
 
     LDOTRIM:
       LDO1V5: [0, "LDO output 1.5V"]
@@ -495,3 +495,133 @@ EXTI:
     "IF*":
       _write:
         Reset: [1, "Reset interrupt flag on this line"]
+
+PFIC:
+  _delete:
+    - STK_CTLR
+
+  CFGR:
+    _modify:
+      "*SET,KEYCODE":
+        _write_constraint: "enum"
+
+    HWSTKCTRL:
+      Enable: [0, "Enable hardware stack"]
+      Disable: [1, "Disable hardware stack"]
+
+    NESTCTRL:
+      Enable: [0, "Enable interrupt nesting"]
+      Disable: [1, "Disable interrupt nesting"]
+
+    NMISET,EXCSET:
+      _write:
+        Set: [1, "Set interrupt"]
+
+    "*RESET":
+      _write:
+        Reset: [1, "Reset the module"]
+
+    KEYCODE:
+      _write:
+        Key1: [0xFA05, "HWSTK and NEST key"]
+        Key2: [0xBCAF, "NMI and EXC key"]
+        Key3: [0xBEEF, "System Reset key"]
+  
+  GISR:
+    NESTSTA:
+      _read:
+        NoInterrupt: [0, "No interrupt ongoing"]
+        Primary: [1, "Primary interrupt ongoing"]
+        Secondary: [3, "Secondary interrupt ongoing"]
+
+    GACTSTA:
+      _read:
+        NoInterrupt: [0, "No interrupt ongoing"]
+        HasInterrupt: [1, "Interrupt ongoing"]
+
+    GPENDSTA:
+      _read:
+        NoPendingInterrupt: [0, "No interrupt pending"]
+        HasPendingInterrupt: [1, "Has interrupt pending"]
+
+  SCTLR:
+    SLEEPONEXIT:
+      Continue: [0, "Don't sleep after exiting interrupt service"]
+      Sleep: [1, "Enter sleep mode after exiting interrupt service"]
+
+    SLEEPDEEP:
+      Sleep: [0, "Sleep mode"]
+      DeepSleep: [1, "Deep Sleep mode"]
+
+    WFITOWFE:
+      Normal: [0, "Nothing"]
+      Enable: [1, "WFI will be treated as WFE"]
+
+    SEVONPEND:
+      OnlyEnabled: [0, "Only enabled events and interrupts can wake up the system"]
+      AllInterrupts: [1, "Enabled events and all interrupts can wake up the system"]
+
+    SETEVENT:
+      _write:
+        Set: [1, "Set WFE event"]
+
+_add:
+  SYSTICK:
+    description: System Tick Peripheral
+    groupName: SYSTICK
+    baseAddress: 0xE000F000
+    addressBlock:
+      offset: 0x0
+      size: 0x14 # FIXME: need to verify
+      usage: "registers"
+    registers:
+      CTLR:
+        description: SysTick Control register
+        addressOffset: 0x0
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          STE:
+            description: Enable SysTick
+            bitOffset: 0
+            bitWidth: 1
+      CNTL:
+        description: SysTick counter low bits
+        addressOffset: 0x4
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          CNTL:
+            description: SysTick counter low bits
+            bitOffset: 0
+            bitWidth: 32
+      CNTH:
+        description: SysTick counter high bits
+        addressOffset: 0x8
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          CNTL:
+            description: SysTick counter high bits
+            bitOffset: 0
+            bitWidth: 32
+      CMPLR:
+        description: SysTick compare low bits
+        addressOffset: 0xC
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          CNTL:
+            description: SysTick compare low bits
+            bitOffset: 0
+            bitWidth: 32
+      CMPHR:
+        description: SysTick compare high bits
+        addressOffset: 0x10
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          CNTL:
+            description: SysTick compare high bits
+            bitOffset: 0
+            bitWidth: 32

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -12,3 +12,255 @@ _svd: ../svd/fixed/ch32v103.svd
       - "R32_"
       - "RB_"
       - " "
+
+PWR:
+  CTLR:
+    _modify:
+      LPDS,PDDS,CWUF,CSBF,PLS:
+        _write_constraint: "enum"
+
+    LPDS:
+      Normal: [0, "Regulator works normally at halting mode"]
+      LowPower: [1, "Regulator works at low power at halting mode"]
+
+    PDDS:
+      Halting: [0, "Turn into halting mode on deepsleep"]
+      StandBy: [1, "Turn into stand-by mode on deepsleep"]
+
+    CWUF:
+      _write:
+        Clear: [1, "Clear Wake-Up Flag"]
+
+    CSBF:
+      _write:
+        Clear: [1, "Clear Stand-By Flag"]
+
+    PLS:
+      R265F250: [0, "Rising edge 2.65V, falling edge 2.5V"]
+      R287F270: [1, "Rising edge 2.87V, falling edge 2.7V"]
+      R307F289: [2, "Rising edge 3.07V, falling edge 2.89V"]
+      R327F308: [3, "Rising edge 3.27V, falling edge 3.08V"]
+      R346F327: [4, "Rising edge 3.46V, falling edge 3.27V"]
+      R376F355: [5, "Rising edge 3.76V, falling edge 3.55V"]
+      R407F384: [6, "Rising edge 4.07V, falling edge 3.84V"]
+      R443F413: [7, "Rising edge 4.43V, falling edge 4.13V"]
+
+  CSR:
+    PVDO:
+      _read:
+        Higher: [0, "VDD and VDDA is higher than PVD threshold"]
+        Lower: [1, "VDD and VDDA is lower than PVD threshold"]
+
+RCC:
+  CTLR:
+    "*RDY":
+      _read:
+        NotReady: [0, "Clock not ready"]
+        Ready: [1, "Clock ready"]
+
+    "*ON":
+      "Off": [0, "System Off"]
+      "On": [1, "System On"]
+
+    HSEBYP:
+      NotBypassed: [0, "HSE crystal oscillator not bypassed"]
+      Bypassed: [1, "HSE crystal oscillator bypassed with external clock"]
+    
+  CFGR0:
+    _modify:
+      "*":
+        _write_constraint: "enum"
+      SWS:
+        _write_constraint: "none"
+
+    SW:
+      HSI: [0, "HSI as system clock"]
+      HSE: [1, "HSE as system clock"]
+      PLL: [2, "PLL as system clock"]
+    
+    SWS:
+      _read:
+        HSI: [0, "HSI as system clock"]
+        HSE: [1, "HSE as system clock"]
+        PLL: [2, "PLL as system clock"]
+
+    HPRE:
+      NoDiv: [0, "AHB clock source SYSCLK no division"]
+      Div2: [8, "AHB clock source SYSCLK divided by 2"]
+      Div4: [9, "AHB clock source SYSCLK divided by 4"]
+      Div8: [10, "AHB clock source SYSCLK divided by 8"]
+      Div16: [11, "AHB clock source SYSCLK divided by 16"]
+      Div64: [12, "AHB clock source SYSCLK divided by 64"]
+      Div128: [13, "AHB clock source SYSCLK divided by 128"]
+      Div256: [14, "AHB clock source SYSCLK divided by 256"]
+      Div512: [15, "AHB clock source SYSCLK divided by 512"]
+
+    "PPRE[12]":
+      NoDiv: [0, "APB clock source HCLK no division"]
+      Div2: [4, "APB clock source HCLK divided by 2"]
+      Div4: [5, "APB clock source HCLK divided by 4"]
+      Div8: [6, "APB clock source HCLK divided by 8"]
+      Div16: [7, "APB clock source HCLK divided by 16"]
+
+    ADCPRE:
+      Div2: [0, "ADC clock source PCLK2 divided by 2"]
+      Div4: [1, "ADC clock source PCLK2 divided by 4"]
+      Div6: [2, "ADC clock source PCLK2 divided by 6"]
+      Div8: [3, "ADC clock source PCLK2 divided by 8"]
+
+    PLLSRC:
+      HSI: [0, "HSI as PLL clock source"]
+      HSE: [1, "HSE as PLL clock source"]
+
+    PLLXTPRE:
+      NoDiv: [0, "PLL clock source HSE no division"]
+      Div2: [1, "PLL clock source HSE divided by 2"]
+
+    PLLMUL:
+      Mul2: [0, "PLL output multiplier 2"]
+      Mul3: [1, "PLL output multiplier 3"]
+      Mul4: [2, "PLL output multiplier 4"]
+      Mul5: [3, "PLL output multiplier 5"]
+      Mul6: [4, "PLL output multiplier 6"]
+      Mul7: [5, "PLL output multiplier 7"]
+      Mul8: [6, "PLL output multiplier 8"]
+      Mul9: [7, "PLL output multiplier 9"]
+      Mul10: [8, "PLL output multiplier 10"]
+      Mul11: [9, "PLL output multiplier 11"]
+      Mul12: [10, "PLL output multiplier 12"]
+      Mul13: [11, "PLL output multiplier 13"]
+      Mul14: [12, "PLL output multiplier 14"]
+      Mul15: [13, "PLL output multiplier 15"]
+      Mul16: [14, "PLL output multiplier 16"]
+
+    USBPRE:
+      Direct: [1, "USB clock source use PLL directly"]
+      PLL1P5: [0, "USB clock source PLL divided by 1.5"]
+
+    MCO:
+      NoOutput: [0, "No microcontroller clock output"]
+      SYSCLK: [4, "Output SYSCLK"]
+      HSI: [5, "Output HSI"]
+      HSE: [6, "Output HSE"]
+      PLLDiv2: [7, "Output PLL divided by 2"]
+
+  INTR:
+    _modify:
+      "*C":
+        _write_constraint: "enum"
+
+    "*F":
+      _read:
+        NotInterrupted: [0, "No interrupt occurred"]
+        Interrupted: [1, "Interrupt occurred"]
+
+    "*IE":
+      Disable: [0, "Disable ready interrupt"]
+      Enable: [1, "Enable ready interrupt"]
+
+    
+    "*C":
+      _write:
+        Clear: [1, "Clear interrupt flag"]
+
+  APB?PRSTR,AHBRSTR:
+    "*":
+      _write:
+        Reset: [1, "Reset peripheral"]
+
+  AHBPCENR,APB?PCENR:
+    "*":
+      Disable: [0, "Disable module"]
+      Enable: [1, "Enable module"]
+
+  BDCTLR:
+    _modify:
+      RTCSEL:
+        _write_constraint: "enum"
+
+    LSERDY:
+      _read:
+        NotReady: [0, "Clock not ready"]
+        Ready: [1, "Clock ready"]
+
+    LSEON:
+      "Off": [0, "Clock Off"]
+      "On": [1, "Clock On"]
+
+    LSEBYP:
+      NotBypassed: [0, "LSE crystal oscillator not bypassed"]
+      Bypassed: [1, "LSE crystal oscillator bypassed with external clock"]
+
+    RTCSEL:
+      NoClock: [0, "No clock as RTC clock source"]
+      LSE: [1, "LSE as RTC clock source"]
+      LSI: [2, "LSI as RTC clock source"]
+      HSE: [3, "HSE divided by 128 as RTC clock source"]
+
+    RTCEN:
+      Disable: [0, "Disable RTC"]
+      Enable: [1, "Enable RTC"]
+
+    BDRST:
+      Cancel: [0, "Cancel back domain reset"]
+      Reset: [1, "Reset back domain"]
+
+  RSTSCKR:
+    _modify:
+      RMVF:
+        _write_constraint: "enum"
+
+    "*F":
+      _read:
+        Nothing: [0, "No reset occurred"]
+        HasReset: [1, "Reset occurred"]
+
+    RMVF:
+      _write:
+        Clear: [1, "Remove reset flags"]
+
+    LSIRDY:
+      _read:
+        NotReady: [0, "Clock not ready"]
+        Ready: [1, "Clock ready"]
+
+    LSION:
+      "Off": [0, "Clock Off"]
+      "On": [1, "Clock On"]
+    
+EXTEND:
+  EXTEND_CTR:
+    USBDLS:
+      FullSpeed: [0, "USBD full speed"]
+      LowSpeed: [1, "USBD low speed"]
+
+    USBDPU:
+      Disable: [0, "Disable USBD internal pull-up resistor"]
+      Enable: [1, "Enable USBD internal pull-up resistor"]
+
+    USBHDIO:
+      Other: [0, "Use PB6/PB7 as other functions"]
+      USBHD: [1, "Use PB6/PB7 as USBHD function"]
+
+    USB5VSEL:
+      3V3: [0, "VDD is 3.3V"]
+      5V: [1, "VDD is 5V"]
+
+    HSIPRE:
+      Div2: [0, "HSI divided by 2 as PLL clock source"]
+      NoDiv: [1, "HSI directly as PLL clock source"]
+
+    LKUPEN:
+      Disable: [0, "Disable lock-up reset"]
+      Enable: [1, "Enable lock-up reset"]
+
+    LKUPRESET:
+      _read:
+        Normal: [0, "No lock-up reset occurred"]
+        Reset: [1, "Lock-up reset occurred"]
+      _write:
+        Clear: [1, "Clear reset flag"] # ?? CH32xRM says set 1 to clear
+
+    LDOTRIM:
+      1V5: [0, "LDO output 1.5V"]
+      1V62: [1, "LDO output 1.62V"]

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -32,6 +32,9 @@ _add:
       offset: 0x0
       size: 0x14 # FIXME: need to verify
       usage: "registers"
+    interrupts:
+      SysTick:
+        value: 12
     registers:
       CTLR:
         description: SysTick Control register
@@ -313,6 +316,11 @@ PWR:
         Lower: [1, "VDD and VDDA is lower than PVD threshold"]
 
 RCC:
+  _modify:
+    _interrupts:
+      RCC:
+        value: 21
+
   CTLR:
     "*RDY":
       _read:
@@ -784,6 +792,17 @@ PFIC:
   _delete:
     - STK_CTLR
 
+  _add:
+    _interrupts:
+      Reset:
+        value: 1
+      NMI:
+        value: 2
+      EXC:
+        value: 3
+      SWI:
+        value: 14
+
   CFGR:
     _modify:
       "*SET,KEYCODE":
@@ -1031,6 +1050,23 @@ AFIO:
         Disabled: [4, "SWD disabled"]
 
 DMA:
+  _modify:
+    _interrupts:
+      DMA1_Channel1:
+        name: DMA1_CH1
+      DMA1_Channel2:
+        name: DMA1_CH2
+      DMA1_Channel3:
+        name: DMA1_CH3
+      DMA1_Channel4:
+        name: DMA1_CH4
+      DMA1_Channel5:
+        name: DMA1_CH5
+      DMA1_Channel6:
+        name: DMA1_CH6
+      DMA1_Channel7:
+        name: DMA1_CH7
+
   INTFR:
     GIF?:
       _read:
@@ -1385,6 +1421,16 @@ TIM1:
     CHCTLR2_Output:
       name: "CHCTLR2O"
       displayName: "CHCTLR2O"
+    _interrupts:
+      TIM1_BRK_TIM9:
+        name: TIM1_BRK
+        description: TIM1 Break interrupt
+      TIM1_UP_TIM10:
+        name: TIM1_UP
+        description: TIM1 Update interrupt
+      TIM1_TRG_COM_TIM11:
+        name: TIM1_TRG_COM
+        description: TIM1 Trigger and Commutation interrupts
 
   CTLR1:
     _modify:

--- a/devices/ch32v103.yaml
+++ b/devices/ch32v103.yaml
@@ -2132,3 +2132,52 @@ TIM2:
 
   # CCER:
     # TODO: not documented, need discussion
+
+DAC1:
+  CTLR:
+    _modify:
+      TSEL?,WAVE?,MAMP?:
+        _write_constraint: "enum"
+        
+    EN?:
+      Disabled: [0, "DAC channel disabled"]
+      Enabled: [1, "DAC channel enabled"]
+
+    BOFF?:
+      Enabled: [0, "DAC channel output buffer enabled"]
+      Disabled: [1, "DAC channel output buffer disabled"]
+
+    TEN?:
+      Disabled: [0, "DAC channel trigger disabled"]
+      Enabled: [1, "DAC channel trigger enabled"]
+
+    TSEL?:
+      TIM3: [1, "TIM3 TRG0"]
+      TIM2: [4, "TIM2 TRG0"]
+      TIM4: [5, "TIM4 TRG0"]
+      EXTI9: [6, "EXTI 9"]
+      Software: [7, "Software trigger"]
+
+    WAVE?:
+      Disabled: [0, "Wave generator disabled"]
+      Noise: [1, "Noise generator enabled"]
+      Triangular: [2, "Triangular wave enabled"]
+      # FIXME: not sure if we can turn both of them on by setting 0b11
+
+    MAMP?:
+      NoShutting0Amp1: [0, "No shutting on LSFR bit 0/Triangular wave amplitude 1"]
+      NoShutting10Amp3: [1, "No shutting on LSFR bits [1:0]/Triangular wave amplitude 3"]
+      NoShutting20Amp7: [2, "No shutting on LSFR bits [2:0]/Triangular wave amplitude 7"]
+      NoShutting30Amp15: [3, "No shutting on LSFR bits [3:0]/Triangular wave amplitude 15"]
+      NoShutting40Amp31: [4, "No shutting on LSFR bits [4:0]/Triangular wave amplitude 31"]
+      NoShutting50Amp63: [5, "No shutting on LSFR bits [5:0]/Triangular wave amplitude 63"]
+      NoShutting60Amp127: [6, "No shutting on LSFR bits [6:0]/Triangular wave amplitude 127"]
+      NoShutting70Amp255: [7, "No shutting on LSFR bits [7:0]/Triangular wave amplitude 255"]
+      NoShutting80Amp511: [8, "No shutting on LSFR bits [8:0]/Triangular wave amplitude 511"]
+      NoShutting90Amp1023: [9, "No shutting on LSFR bits [9:0]/Triangular wave amplitude 1023"]
+      NoShutting100Amp2047: [10, "No shutting on LSFR bits [10:0]/Triangular wave amplitude 2047"]
+      NoShutting110Amp4095: [11, "No shutting on LSFR bits [11:0]/Triangular wave amplitude 4095"]
+
+    DMAEN?:
+      Disabled: [0, "DAC channel DMA disabled"]
+      Enabled: [1, "DAC channel DMA enabled"]

--- a/peripherals/flash.yaml
+++ b/peripherals/flash.yaml
@@ -1,0 +1,97 @@
+FLASH:
+  ACTLR:
+    LATENCY:
+      Zero: [0, "No latency, 0 < SYSCLK <= 24MHz recommended"]
+      One: [1, "24MHz < SYSCLK <= 48MHz recommended"]
+      Two: [2, "48MHz < SYSCLK <= 72MHz recommended"]
+
+    PRFTBE:
+      Disabled: [0, "Prefetch buffer disabled"]
+      Enabled: [1, "Prefetch buffer enabled"]
+
+    PRFTBS:
+      _read:
+        Disabled: [0, "Prefetch buffer disabled"]
+        Enabled: [1, "Prefetch buffer enabled"]
+
+  KEYR:
+    KEYR:
+      _write:
+        RDPRT: [0x000000A5, "RDPRT"]
+        Key1: [0x45670123, "Key1"]
+        Key2: [0xCDEF89AB, "Key2"]
+
+  STATR:
+    EOP:
+      _read:
+        Operating: [0, "Operating"]
+        Done: [1, "End of operation"]
+      _W1C:
+        Clear: [1, "Clear this flag"]
+
+    WRPRTERR:
+      _read:
+        NoError: [0, "No error"]
+        Error: [1, "Error"]
+      _W1C:
+        Clear: [1, "Clear this flag"]
+
+    BSY:
+      _read:
+        Idle: [0, "Operation accomplished or error"]
+        Busy: [1, "FLASH in operation"]
+
+  CTLR:
+    BUFRST:
+      Reset: [1, "Conduct buffer data clear"]
+    BUFLOAD:
+      Load: [1, "Conduct buffer data load"]
+    FTER:
+      Erase: [1, "Conduct fast erase"]
+    FTPG:
+      Program: [1, "Conduct fast programming"]
+    FLOCK:
+      _read:
+        Unlocked: [0, "Unlocked"]
+        Locked: [1, "Locked"]
+      _write:
+        Lock: [1, "Lock"]
+    EOPIE,ERRIE:
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+    OBWRE:
+      _W0C: {}
+    LOCK:
+      _write:
+        Lock: [1, "Lock"]
+    STRT:
+      _write:
+        Start: [1, "Conduct erase or programming"]
+    OBER:
+      Erase: [1, "Conduct erase"]
+    OBPG:
+      Program: [1, "Conduct programming"]
+    MER:
+      Erase: [1, "Erase USER"]
+    PER:
+      Erase: [1, "Erase 1KB"]
+    PG:
+      Program: [1, "Conduct programming"]
+
+  OBR:
+    _delete:
+      - Data?
+
+  WPR:
+    _split: [WRP]
+
+    "WRP*":
+      _read:
+        Activated: [0, "Write protection activated"]
+        Deactivated: [1, "Write protection deactivated"]
+
+  MODEKEYR:
+    MODEKEYR:
+      _write:
+        Key1: [0x45670123, "Key1"]
+        Key2: [0xCDEF89AB, "Key2"]

--- a/peripherals/usbd.yaml
+++ b/peripherals/usbd.yaml
@@ -1,0 +1,164 @@
+# reference: https://github.com/stm32-rs/stm32-rs/blob/master/peripherals/usb/usb.yaml
+
+USBD:
+  _modify:
+    "*":
+      size: 0x10
+
+  CNTR:
+    _modify:
+      FRES,FSUSP,RESUME:
+        _write_constraint: "enum"
+
+    CTRM:
+      Disabled: [0, "Correct Transfer (CTR) Interrupt disabled"]
+      Enabled: [1, "CTR Interrupt enabled, an interrupt request is generated when the corresponding bit in the ISTR register is set"]
+    PMAOVRM:
+      Disabled: [0, "PMAOVR Interrupt disabled"]
+      Enabled: [1, "PMAOVR Interrupt enabled, an interrupt request is generated when the corresponding bit in the ISTR register is set"]
+    ERRM:
+      Disabled: [0, "ERR Interrupt disabled"]
+      Enabled: [1, "ERR Interrupt enabled, an interrupt request is generated when the corresponding bit in the ISTR register is set"]
+    WKUPM:
+      Disabled: [0, "WKUP Interrupt disabled"]
+      Enabled: [1, "WKUP Interrupt enabled, an interrupt request is generated when the corresponding bit in the ISTR register is set"]
+    SUSPM:
+      Disabled: [0, "Suspend Mode Request SUSP Interrupt disabled"]
+      Enabled: [1, "SUSP Interrupt enabled, an interrupt request is generated when the corresponding bit in the ISTR register is set"]
+    RESETM:
+      Disabled: [0, "RESET Interrupt disabled"]
+      Enabled: [1, "RESET Interrupt enabled, an interrupt request is generated when the corresponding bit in the ISTR register is set"]
+    SOFM:
+      Disabled: [0, "SOF Interrupt disabled"]
+      Enabled: [1, "SOF Interrupt enabled, an interrupt request is generated when the corresponding bit in the ISTR register is set"]
+    ESOFM:
+      Disabled: [0, "ESOF Interrupt disabled"]
+      Enabled: [1, "ESOF Interrupt enabled, an interrupt request is generated when the corresponding bit in the ISTR register is set"]
+    RESUME:
+      Idle: [0, "No action"]
+      Requested: [1, "Resume requested"]
+    FSUSP:
+      NoEffect: [0, "No effect"]
+      Suspend: [1, "Enter suspend mode. Clocks and static power dissipation in the analog transceiver are left unaffected"]
+    LPMODE:
+      Disabled: [0, "No low-power mode"]
+      Enabled: [1, "Enter low-power mode"]
+    PDWN:
+      Disabled: [0, "No power down"]
+      Enabled: [1, "Enter power down mode"]
+    FRES:
+      NoReset: [0, "Clear USB reset"]
+      Reset: [1, "Force a reset of the USB peripheral, exactly like a RESET signaling on the USB"]
+
+  ISTR:
+    _modify:
+      CTR,DIR: # NOTE: wrong RM
+        access: read-only
+
+    CTR:
+      _read:
+        NotCompleted: [0, "not completed"]
+        Completed: [1, "endpoint has successfully completed a transaction"]
+    PMAOVR:
+      _read:
+        NotOverrun: [0, "Overrun is not occurred"]
+        Overrun: [1, "microcontroller has not been able to respond in time to an USB memory request"]
+      _W0C:
+        Clear: [0, "Clear this flag"]
+    ERR:
+      _read:
+        NotOverrun: [0, "Errors are not occurred"]
+        Error: [1, "One of No ANSwer, Cyclic Redundancy Check, Bit Stuffing or Framing format Violation error occurred"]
+      _W0C:
+        Clear: [0, "Clear this flag"]
+    WKUP:
+      _read:
+        NotWakeup: [0, "NotWakeup"]
+        Wakeup: [1, "activity is detected that wakes up the USB peripheral"]
+      _W0C:
+        Clear: [0, "Clear this flag"]
+    SUSP:
+      _read:
+        NotSuspend: [0, "NotSuspend"]
+        Suspend: [1, "no traffic has been received for 3 ms, indicating a suspend mode request from the USB bus"]
+      _W0C:
+        Clear: [0, "Clear this flag"]
+    RESET:
+      _read:
+        NotReset: [0, "NotReset"]
+        Reset: [1, "peripheral detects an active USB RESET signal at its inputs"]
+      _W0C:
+        Clear: [0, "Clear this flag"]
+    SOF:
+      _read:
+        NotStartOfFrame: [0, "NotStartOfFrame"]
+        StartOfFrame: [1, "beginning of a new USB frame and it is set when a SOF packet arrives through the USB bus"]
+      _W0C:
+        Clear: [0, "Clear this flag"]
+    ESOF:
+      _read:
+        NotExpectedStartOfFrame: [0, "NotExpectedStartOfFrame"]
+        ExpectedStartOfFrame: [1, "an SOF packet is expected but not received"]
+      _W0C:
+        Clear: [0, "Clear this flag"]
+    DIR:
+      _read:
+        To: [0, "data transmitted by the USB peripheral to the host PC"]
+        From: [1, "data received by the USB peripheral from the host PC"]
+
+  FNR:
+    RXDP:
+      _read:
+        NotReceived: [0, "not received"]
+        Received: [1, "received data plus upstream port data line"]
+    RXDM:
+      _read:
+        NotReceived: [0, "not received"]
+        Received: [1, "received data minus upstream port data line"]
+    LCK:
+      _read:
+        NotLocked: [0, "not locked"]
+        Locked: [1, "the frame timer remains in this state until an USB reset or USB suspend event occurs"]
+
+  DADDR:
+    EF:
+      Disabled: [0, "USB device disabled"]
+      Enabled: [1, "USB device enabled"]
+
+  EP?R:
+    CTR_RX:
+      _W0C: {}
+    DTOG_RX:
+      _read:
+        DATA0: [0, "Expect DATA0"]
+        DATA1: [1, "Expect DATA1"]
+      _W1T: {}
+    STAT_RX:
+      _read:
+        Disabled: [0, "all reception requests addressed to this endpoint are ignored"]
+        Stall: [1, "the endpoint is stalled and all reception requests result in a STALL handshake"]
+        Nak: [2, "the endpoint is naked and all reception requests result in a NAK handshake"]
+        Valid: [3, "this endpoint is enabled for reception"]
+      _W1T: {}
+    SETUP:
+      _read:
+        NotSetup: [0, "Not setup"]
+        Setup: [1, "Setup"]
+    EP_TYPE:
+      Bulk: [0, "Bulk endpoint"]
+      Control: [1, "Control endpoint"]
+      Iso: [2, "Iso endpoint"]
+      Interrupt: [3, "Interrupt endpoint"]
+    EP_KIND:
+      # ?
+    CTR_TX:
+      _W0C: {}
+    DTOG_TX:
+      _W1T: {}
+    STAT_TX:
+      _read:
+        Disabled: [0, "all transmission requests addressed to this endpoint are ignored"]
+        Stall: [1, "the endpoint is stalled and all transmission requests result in a STALL handshake"]
+        Nak: [2, "the endpoint is naked and all transmission requests result in a NAK handshake"]
+        Valid: [3, "this endpoint is enabled for transmission"]
+      _W1T: {}

--- a/peripherals/usbd.yaml
+++ b/peripherals/usbd.yaml
@@ -4,6 +4,9 @@ USBD:
   _modify:
     "*":
       size: 0x10
+    _interrupts:
+      USB_FS_WKUP:
+        name: USBWakeUp
 
   CNTR:
     _modify:


### PR DESCRIPTION
This pull request delivers a fix to `ch32v103.svd` using [svdtools](https://github.com/stm32-rs/svdtools) according to the [official RM](http://www.wch-ic.com/downloads/CH32xRM_PDF.html).

Also, best efforts are paid to make most of the possible fields available with `enumeratedValues`.

This pull request is still a work in progress. However, the official RM and the SVD file are somehow too buggy. Hence I opened this pull request to ask for some advice so that I can adjust them in time.

TODO lists:
- [x] Add missing peripherals
  - [x] SysTick
  - [x] TKEY
- [ ] Revise all peripherals and their registers, and `enumeratedValue` possible fields
  - [x] PWR
  - [x] RCC
  - [x] BKP
  - [x] CRC
  - [x] RTC
  - [x] IWDG
  - [x] WWDG
  - [x] EXTI
  - [x] PFIC
  - [x] SysTick
  - [x] DMA
  - [x] ADC
  - [x] TKEY
  - [x] TIM1*
  - [x] TIM2/3/4*
  - [x] DAC
  - [x] USART
  - [x] I2C
  - [x] SPI
  - [x] USBD
  - [ ] USBHD
  - [ ] CAN
  - [x] ~~ESIG~~
  - [x] FLASH
- [x] Revise interrupts
- [ ] Clear all `# FIXME` and `# TODO`
- [ ] Split out some common peripherals to `peripherals` YAML for further use. stm32-rs repository is worth referring to.
- [ ] Check for convenience in HAL development

I also commented in the YAML where I'm not sure about something, namely the following:
- The whole SysTick is missing in the SVD, and it is different from [systick_64bit.yaml](https://github.com/ch32-rs/ch32-rs/blob/main/peripherals/systick_64bit.yaml) according to RM. Also, the `addressBlock.size` attribute is unknown.
- The whole TKEY peripheral is missing in the SVD, and it partially overlaps with ADC registers. This is reasonable since it works together with ADC, but I'm not sure if the current fix will mess up the ownership in HAL development.
- The timers(TIM1/2/3/4) registers are very confusingly documented. Plus I'm not very familiar with the TIM mechanism, which makes the naming and enumerating a complete mess. __THOROUGH REVIEW REQUIRED!!!__
  - It seems that `CCxS` fields of `CHCTLRyI/O` registers are wrongly documented, particularly the `ICx` to `TIx` mapping.
  - `CCER` register fields are not documented. Discussion needed.
- USART
  - `CTLR1.UE` field is different from that of STM32, and quite contrast its name. Maybe also wrong documentation.
  - `CTLR2.LBCL` field is wrongly documented and needs verification
- USBD
  - `CNTR.PDWN` field is missing in RM, however exists in SVD, and also in [stm32-rs](https://github.com/stm32-rs/stm32-rs/blob/master/peripherals/usb/usb.yaml)
- ...and more if I haven't noticed anything

This is not an easy job, and comments are needed.

__DO NOT MERGE UNTIL ALL THE TODOs ARE DONE__