### PR TITLE
Update svd2rust, riscv, and critical-section

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 
@@ -12,7 +12,7 @@ $SVDTOOLS patch devices/ch56x.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch56x.svd.patched
 
 mkdir -p ch56x/src/ch56x
-svd2rust -m --target riscv -o ch56x/src/ch56x -g --strict --pascal_enum_values --max_cluster_size -i svd/fixed/ch56x.svd.patched
+svd2rust -m --target riscv -o ch56x/src/ch56x -g --strict --ident-formats-theme legacy --max_cluster_size -i svd/fixed/ch56x.svd.patched
 
 mv ch56x/src/ch56x/generic.rs ch56x/src/
 rm ch56x/src/ch56x/build.rs
@@ -25,7 +25,7 @@ $SVDTOOLS patch devices/ch57x.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch57x.svd.patched
 
 mkdir -p ch57x/src/ch57x
-svd2rust -m --target riscv -o ch57x/src/ch57x -g --strict --pascal_enum_values --max_cluster_size -i svd/fixed/ch57x.svd.patched
+svd2rust -m --target riscv -o ch57x/src/ch57x -g --strict --ident-formats-theme legacy --max_cluster_size -i svd/fixed/ch57x.svd.patched
 
 mv ch57x/src/ch57x/generic.rs ch57x/src/
 rm ch57x/src/ch57x/build.rs
@@ -37,7 +37,7 @@ $SVDTOOLS patch devices/ch32v30x.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch32v30x.svd.patched
 
 mkdir -p ch32v3/src/ch32v30x
-svd2rust -m --target riscv -o ch32v3/src/ch32v30x -g --strict --pascal_enum_values --max_cluster_size -i svd/fixed/ch32v30x.svd.patched
+svd2rust -m --target riscv -o ch32v3/src/ch32v30x -g --strict --ident-formats-theme legacy --max_cluster_size -i svd/fixed/ch32v30x.svd.patched
 
 mv ch32v3/src/ch32v30x/generic.rs ch32v3/src/
 rm ch32v3/src/ch32v30x/build.rs
@@ -50,7 +50,7 @@ $SVDTOOLS patch devices/ch32v20x.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch32v20x.svd.patched
 
 mkdir -p ch32v2/src/ch32v20x
-svd2rust -m --target riscv -g --strict --pascal_enum_values --max_cluster_size \
+svd2rust -m --target riscv -g --strict --ident-formats-theme legacy --max_cluster_size \
     -o ch32v2/src/ch32v20x -i svd/fixed/ch32v20x.svd.patched
 
 mv ch32v2/src/ch32v20x/generic.rs ch32v2/src/
@@ -65,7 +65,7 @@ $SVDTOOLS patch devices/ch32v103.yaml
 echo "Ignore checking ch32v103.svd.patched. It uses some newer features."
 
 mkdir -p ch32v1/src/ch32v103
-svd2rust -m --target riscv -g --strict --pascal_enum_values --max_cluster_size \
+svd2rust -m --target riscv -g --strict --ident-formats-theme legacy --max_cluster_size \
     -o ch32v1/src/ch32v103 -i svd/fixed/ch32v103.svd.patched
 
 mv ch32v1/src/ch32v103/generic.rs ch32v1/src/
@@ -79,7 +79,7 @@ $SVDTOOLS patch devices/ch58x.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch58x.svd.patched
 
 mkdir -p ch58x/src/ch58x
-svd2rust -m --target riscv -o ch58x/src/ch58x -g --strict --pascal_enum_values --max_cluster_size -i svd/fixed/ch58x.svd.patched
+svd2rust -m --target riscv -o ch58x/src/ch58x -g --strict --ident-formats-theme legacy --max_cluster_size -i svd/fixed/ch58x.svd.patched
 
 mv ch58x/src/ch58x/generic.rs ch58x/src/
 rm ch58x/src/ch58x/build.rs
@@ -91,7 +91,7 @@ $SVDTOOLS patch devices/ch59x.yaml
 # xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch59x.svd.patched
 
 mkdir -p ch59x/src/ch59x
-svd2rust -m --target riscv -o ch59x/src/ch59x -g --strict --pascal_enum_values --max_cluster_size -i svd/fixed/ch59x.svd.patched
+svd2rust -m --target riscv -o ch59x/src/ch59x -g --strict --ident-formats-theme legacy --max_cluster_size -i svd/fixed/ch59x.svd.patched
 
 mv ch59x/src/ch59x/generic.rs ch59x/src/
 rm ch59x/src/ch59x/build.rs
@@ -104,7 +104,7 @@ $SVDTOOLS patch devices/ch32v003.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch32v003.svd.patched
 
 mkdir -p ch32v0/src/ch32v003
-svd2rust -m --target riscv -g --strict --pascal_enum_values --max_cluster_size \
+svd2rust -m --target riscv -g --strict --ident-formats-theme legacy --max_cluster_size \
     -o ch32v0/src/ch32v003 -i svd/fixed/ch32v003.svd.patched
 
 mv ch32v0/src/ch32v003/generic.rs ch32v0/src/
@@ -117,7 +117,7 @@ $SVDTOOLS patch devices/ch32x035.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch32x035.svd.patched
 
 mkdir -p ch32x0/src/ch32x035
-svd2rust -m --target riscv -g --strict --pascal_enum_values --max_cluster_size \
+svd2rust -m --target riscv -g --strict --ident-formats-theme legacy --max_cluster_size \
     -o ch32x0/src/ch32x035 -i svd/fixed/ch32x035.svd.patched
 
 mv ch32x0/src/ch32x035/generic.rs ch32x0/src/
@@ -131,7 +131,7 @@ $SVDTOOLS patch devices/ch32l103.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch32l103.svd.patched
 
 mkdir -p ch32l1/src/ch32l103
-svd2rust -m --target riscv -g --strict --pascal_enum_values --max_cluster_size \
+svd2rust -m --target riscv -g --strict --ident-formats-theme legacy --max_cluster_size \
     -o ch32l1/src/ch32l103 -i svd/fixed/ch32l103.svd.patched
 
 mv ch32l1/src/ch32l103/generic.rs ch32l1/src/
@@ -144,7 +144,7 @@ $SVDTOOLS patch devices/ch643.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch643.svd.patched
 
 mkdir -p ch643/src/ch643
-svd2rust -m --target riscv -g --strict --pascal_enum_values --max_cluster_size \
+svd2rust -m --target riscv -g --strict --ident-formats-theme legacy --max_cluster_size \
     -o ch643/src/ch643 -i svd/fixed/ch643.svd.patched
 
 mv ch643/src/ch643/generic.rs ch643/src/
@@ -156,7 +156,7 @@ $SVDTOOLS patch devices/ch641.yaml
 xmllint --schema svd/CMSIS-SVD.xsd --noout svd/fixed/ch641.svd.patched
 
 mkdir -p ch641/src/ch641
-svd2rust -m --target riscv -g --strict --pascal_enum_values --max_cluster_size \
+svd2rust -m --target riscv -g --strict --ident-formats-theme legacy --max_cluster_size \
     -o ch641/src/ch641 -i svd/fixed/ch641.svd.patched
 
 mv ch641/src/ch641/generic.rs ch641/src/

--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -18,13 +18,13 @@ import os.path
 import argparse
 import re
 
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 SVD2RUST_VERSION = "0.36.0"
 
 CRATE_VERSIONS = {
-    "ch58x": "0.3.0",
-    "ch59x": "0.1.8",
-    "ch641": "0.0.1",
+    "ch58x": "0.4.0",
+    "ch59x": "0.2.8",
+    "ch641": "0.0.2",
 }
 
 CRATE_DOC_FEATURES = {

--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -19,7 +19,7 @@ import argparse
 import re
 
 VERSION = "0.2.0"
-SVD2RUST_VERSION = "0.31.5"
+SVD2RUST_VERSION = "0.36.0"
 
 CRATE_VERSIONS = {
     "ch58x": "0.3.0",
@@ -71,8 +71,8 @@ categories = ["embedded", "no-std", "hardware-support"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-critical-section = {{ version = "1.1", optional = true }}
-riscv = "0.10.1"
+critical-section = {{ version = "1.2", optional = true }}
+riscv = "0.12"
 vcell = "0.1"
 
 [package.metadata.docs.rs]
@@ -134,7 +134,7 @@ version = "{version}"
 features = ["{device}", "critical-section"]
 
 [dependencies.riscv]
-version = "0.10.1"
+version = "0.12"
 features = ["critical-section-single-hart"]
 ```
 


### PR DESCRIPTION
This allows recent versions of svd2rust, riscv and critical-section to be used. Svd2rust's generated code has API breakages so I've bumped the package versions as well.

I've used `--ident-formats-theme legacy` for now as it breaks dependent packages the least.

Required by https://github.com/ch32-rs/ch58x-hal/pull/8